### PR TITLE
Group samples by taxon in locality pages

### DIFF
--- a/jsondata/dict.json
+++ b/jsondata/dict.json
@@ -106,7 +106,8 @@
         "cookie-banner-accept": "Αποδοχή",
         "cookie-banner-decline": "Απόρριψη",
         "gryphaea": "Γρυφαία",
-        "ostreida": "Οστρείδια"
+        "ostreida": "Οστρείδια",
+        "unclassified": "Ακατηγοριοποίητα"
     },
     "en": {
         "home": "🏡Home",
@@ -215,7 +216,8 @@
         "cookie-banner-accept": "Accept",
         "cookie-banner-decline": "Decline",
         "gryphaea": "Gryphaea",
-        "ostreida": "Ostreida"
+        "ostreida": "Ostreida",
+        "unclassified": "Unclassified"
     },
     "grc": {        
         "home": "🏡Οἰκοσελίς",
@@ -324,6 +326,7 @@
         "cookie-banner-accept": "Ἀποδέχεσθαι",
         "cookie-banner-decline": "Ἀπορρίπτειν",
         "gryphaea": "Γρυφαία",
-        "ostreida": "Ὀστρείδια"
+        "ostreida": "Ὀστρείδια",
+        "unclassified": "Ἀκατηγοριοποίητα"
     }
 }

--- a/localities/abbey-wood.html
+++ b/localities/abbey-wood.html
@@ -57,1276 +57,1399 @@
                 </div>
             </section>
 
-            <section id="abbey-wood-gallery">
-                <div class="tax-subcontainer">
-                    <div class="gallery" id="gallery-">
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(1)">
-                            
-                            <div class="image-two">
-                                <picture class="image-main">
-                                    <source srcset="../images/uk_collection/sample1/thumbs_dir/hypolophodon_sylvestris1_1_thumb.webp 1x" type="image/webp">
-                                    <img loading="lazy" src="../images/uk_collection/sample1/thumbs_dir/hypolophodon_sylvestris1_1_thumb.jpg" alt="Measurement 2-3mm">
-                                </picture>
-                                <div class="image-overlay">+1</div>
+            <section id="abbey-wood-hypolophodon_sylvestris-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/chordata/chondrichthyes/elasmobranchii/dasyatidae/hypolophodon/hypolophodon_sylvestris/hypolophodon_sylvestris.html" style="text-decoration: none;">
+                            <h1 id="hypolophodon_sylvestris"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/chordata/chondrichthyes/elasmobranchii/dasyatidae/hypolophodon/hypolophodon_sylvestris/hypolophodon_sylvestris.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%A5%CF%80%CE%BF%CE%BB%CE%BF%CF%86%CF%8C%CE%B4%CF%89%CE%BD%20%CE%BF%20%CE%B4%CF%81%CF%85%CE%BC%CF%8E%CE%B4%CE%B7%CF%82.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Υπολοφόδων ο δρυμώδης.jpg" alt="Artistic depiction of Hypolophodon sylvestris" id="abbey-wood-hypolophodon_sylvestris-εικόνα">
+                                    </picture>
+                                </a>
                             </div>
                             
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-1" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample1/hypolophodon_sylvestris1_1.jpg" id="gallery-img-1">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample1/thumbs_dir/hypolophodon_sylvestris1_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample1/thumbs_dir/hypolophodon_sylvestris1_1_thumb.jpg" alt="Measurement 2-3mm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample1/hypolophodon_sylvestris1_2.jpg" id="gallery-img-2">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample1/thumbs_dir/hypolophodon_sylvestris1_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample1/thumbs_dir/hypolophodon_sylvestris1_2_thumb.jpg" alt="Lateral view">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(2)">
                             
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_1_thumb.jpg" alt="Measurement 3-4mm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_2_thumb.jpg" alt="Lateral view">
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(1)">
+                                    
+                                    <div class="image-two">
+                                        <picture class="image-main">
+                                            <source srcset="../images/uk_collection/sample1/thumbs_dir/hypolophodon_sylvestris1_1_thumb.webp 1x" type="image/webp">
+                                            <img loading="lazy" src="../images/uk_collection/sample1/thumbs_dir/hypolophodon_sylvestris1_1_thumb.jpg" alt="Measurement 2-3mm">
                                         </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_3_thumb.jpg" alt="Occlusal view">
-                                        </picture>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-2" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample2/hypolophodon_sylvestris2_1.jpg" id="gallery-img-3">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_1_thumb.jpg" alt="Measurement 3-4mm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample2/hypolophodon_sylvestris2_2.jpg" id="gallery-img-4">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_2_thumb.jpg" alt="Lateral view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample2/hypolophodon_sylvestris2_3.jpg" id="gallery-img-5">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_3_thumb.jpg" alt="Occlusal view">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(3)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_1_thumb.jpg" alt="Measurement 5-6mm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_2_thumb.jpg" alt="Lateral view">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_3_thumb.jpg" alt="Lateral view">
-                                        </picture>
-                                        
                                         <div class="image-overlay">+1</div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-1" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample1/hypolophodon_sylvestris1_1.jpg" id="gallery-img-1">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample1/thumbs_dir/hypolophodon_sylvestris1_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample1/thumbs_dir/hypolophodon_sylvestris1_1_thumb.jpg" alt="Measurement 2-3mm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample1/hypolophodon_sylvestris1_2.jpg" id="gallery-img-2">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample1/thumbs_dir/hypolophodon_sylvestris1_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample1/thumbs_dir/hypolophodon_sylvestris1_2_thumb.jpg" alt="Lateral view">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-3" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample3/hypolophodon_sylvestris3_1.jpg" id="gallery-img-6">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_1_thumb.jpg" alt="Measurement 5-6mm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample3/hypolophodon_sylvestris3_2.jpg" id="gallery-img-7">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_2_thumb.jpg" alt="Lateral view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample3/hypolophodon_sylvestris3_3.jpg" id="gallery-img-8">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_3_thumb.jpg" alt="Lateral view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample3/hypolophodon_sylvestris3_4.jpg" id="gallery-img-9">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_4_thumb.jpg" alt="Occlusal view">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(4)">
                             
-                            <div class="image-two">
-                                <picture class="image-main">
-                                    <source srcset="../images/uk_collection/sample4/thumbs_dir/hypolophodon_sylvestris4_1_thumb.webp 1x" type="image/webp">
-                                    <img loading="lazy" src="../images/uk_collection/sample4/thumbs_dir/hypolophodon_sylvestris4_1_thumb.jpg" alt="Measurement 5-6mm">
-                                </picture>
-                                <div class="image-overlay">+1</div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-4" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample4/hypolophodon_sylvestris4_1.jpg" id="gallery-img-10">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample4/thumbs_dir/hypolophodon_sylvestris4_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample4/thumbs_dir/hypolophodon_sylvestris4_1_thumb.jpg" alt="Measurement 5-6mm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample4/hypolophodon_sylvestris4_2.jpg" id="gallery-img-11">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample4/thumbs_dir/hypolophodon_sylvestris4_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample4/thumbs_dir/hypolophodon_sylvestris4_2_thumb.jpg" alt="Lateral view">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(5)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_1_thumb.jpg" alt="Measurement 3-4mm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_2_thumb.jpg" alt="Occlusal view, worn enameloid">
-                                        </picture>
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(2)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_1_thumb.jpg" alt="Measurement 3-4mm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_2_thumb.jpg" alt="Lateral view">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_3_thumb.jpg" alt="Occlusal view">
+                                                </picture>
+                                                
+                                            </div>
+                                        </div>
                                     </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_3_thumb.jpg" alt="Lateral view">
-                                        </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-2" style="display: none;">
                                         
+                                        
+                                        <a href="../images/uk_collection/sample2/hypolophodon_sylvestris2_1.jpg" id="gallery-img-3">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_1_thumb.jpg" alt="Measurement 3-4mm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample2/hypolophodon_sylvestris2_2.jpg" id="gallery-img-4">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_2_thumb.jpg" alt="Lateral view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample2/hypolophodon_sylvestris2_3.jpg" id="gallery-img-5">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample2/thumbs_dir/hypolophodon_sylvestris2_3_thumb.jpg" alt="Occlusal view">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(3)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_1_thumb.jpg" alt="Measurement 5-6mm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_2_thumb.jpg" alt="Lateral view">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_3_thumb.jpg" alt="Lateral view">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+1</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-3" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample3/hypolophodon_sylvestris3_1.jpg" id="gallery-img-6">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_1_thumb.jpg" alt="Measurement 5-6mm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample3/hypolophodon_sylvestris3_2.jpg" id="gallery-img-7">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_2_thumb.jpg" alt="Lateral view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample3/hypolophodon_sylvestris3_3.jpg" id="gallery-img-8">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_3_thumb.jpg" alt="Lateral view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample3/hypolophodon_sylvestris3_4.jpg" id="gallery-img-9">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample3/thumbs_dir/hypolophodon_sylvestris3_4_thumb.jpg" alt="Occlusal view">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(4)">
+                                    
+                                    <div class="image-two">
+                                        <picture class="image-main">
+                                            <source srcset="../images/uk_collection/sample4/thumbs_dir/hypolophodon_sylvestris4_1_thumb.webp 1x" type="image/webp">
+                                            <img loading="lazy" src="../images/uk_collection/sample4/thumbs_dir/hypolophodon_sylvestris4_1_thumb.jpg" alt="Measurement 5-6mm">
+                                        </picture>
                                         <div class="image-overlay">+1</div>
-                                        
                                     </div>
-                                </div>
-                            </div>
-                            
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-5" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample5/hypolophodon_sylvestris5_1.jpg" id="gallery-img-12">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_1_thumb.jpg" alt="Measurement 3-4mm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample5/hypolophodon_sylvestris5_2.jpg" id="gallery-img-13">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_2_thumb.jpg" alt="Occlusal view, worn enameloid">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample5/hypolophodon_sylvestris5_3.jpg" id="gallery-img-14">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_3_thumb.jpg" alt="Lateral view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample5/hypolophodon_sylvestris5_4.jpg" id="gallery-img-15">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_4_thumb.jpg" alt="Occlusal view, worn enameloid">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(6)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_1_thumb.jpg" alt="Measurement 4-5mm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_2_thumb.jpg" alt="Lateral view">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_3_thumb.jpg" alt="Occlusal view, hexagonal, worn enameloiod">
-                                        </picture>
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-4" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample4/hypolophodon_sylvestris4_1.jpg" id="gallery-img-10">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample4/thumbs_dir/hypolophodon_sylvestris4_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample4/thumbs_dir/hypolophodon_sylvestris4_1_thumb.jpg" alt="Measurement 5-6mm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample4/hypolophodon_sylvestris4_2.jpg" id="gallery-img-11">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample4/thumbs_dir/hypolophodon_sylvestris4_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample4/thumbs_dir/hypolophodon_sylvestris4_2_thumb.jpg" alt="Lateral view">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(5)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_1_thumb.jpg" alt="Measurement 3-4mm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_2_thumb.jpg" alt="Occlusal view, worn enameloid">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_3_thumb.jpg" alt="Lateral view">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+1</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-6" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample6/hypolophodon_sylvestris6_1.jpg" id="gallery-img-16">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_1_thumb.jpg" alt="Measurement 4-5mm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample6/hypolophodon_sylvestris6_2.jpg" id="gallery-img-17">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_2_thumb.jpg" alt="Lateral view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample6/hypolophodon_sylvestris6_3.jpg" id="gallery-img-18">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_3_thumb.jpg" alt="Occlusal view, hexagonal, worn enameloiod">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(7)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_1_thumb.jpg" alt="Measurement 3-4mm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_2_thumb.jpg" alt="Occlusal view, hexagonal, worn enameloiod">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_3_thumb.jpg" alt="Lateral view">
-                                        </picture>
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-5" style="display: none;">
                                         
-                                        <div class="image-overlay">+2</div>
+                                        
+                                        <a href="../images/uk_collection/sample5/hypolophodon_sylvestris5_1.jpg" id="gallery-img-12">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_1_thumb.jpg" alt="Measurement 3-4mm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample5/hypolophodon_sylvestris5_2.jpg" id="gallery-img-13">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_2_thumb.jpg" alt="Occlusal view, worn enameloid">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample5/hypolophodon_sylvestris5_3.jpg" id="gallery-img-14">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_3_thumb.jpg" alt="Lateral view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample5/hypolophodon_sylvestris5_4.jpg" id="gallery-img-15">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample5/thumbs_dir/hypolophodon_sylvestris5_4_thumb.jpg" alt="Occlusal view, worn enameloid">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(6)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_1_thumb.jpg" alt="Measurement 4-5mm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_2_thumb.jpg" alt="Lateral view">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_3_thumb.jpg" alt="Occlusal view, hexagonal, worn enameloiod">
+                                                </picture>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-7" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample7/hypolophodon_sylvestris7_1.jpg" id="gallery-img-19">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_1_thumb.jpg" alt="Measurement 3-4mm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample7/hypolophodon_sylvestris7_2.jpg" id="gallery-img-20">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_2_thumb.jpg" alt="Occlusal view, hexagonal, worn enameloiod">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample7/hypolophodon_sylvestris7_3.jpg" id="gallery-img-21">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_3_thumb.jpg" alt="Lateral view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample7/hypolophodon_sylvestris7_4.jpg" id="gallery-img-22">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_4_thumb.jpg" alt="Lateral view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample7/hypolophodon_sylvestris7_5.jpg" id="gallery-img-23">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_5_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_5_thumb.jpg" alt="Root view">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(8)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_1_thumb.jpg" alt="Measurement 4-5mm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_2_thumb.jpg" alt="Lateral view">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_3_thumb.jpg" alt="Occlusal view, worn enameloid">
-                                        </picture>
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-6" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample6/hypolophodon_sylvestris6_1.jpg" id="gallery-img-16">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_1_thumb.jpg" alt="Measurement 4-5mm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample6/hypolophodon_sylvestris6_2.jpg" id="gallery-img-17">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_2_thumb.jpg" alt="Lateral view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample6/hypolophodon_sylvestris6_3.jpg" id="gallery-img-18">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample6/thumbs_dir/hypolophodon_sylvestris6_3_thumb.jpg" alt="Occlusal view, hexagonal, worn enameloiod">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(7)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_1_thumb.jpg" alt="Measurement 3-4mm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_2_thumb.jpg" alt="Occlusal view, hexagonal, worn enameloiod">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_3_thumb.jpg" alt="Lateral view">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+2</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-8" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample8/hypolophodon_sylvestris8_1.jpg" id="gallery-img-24">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_1_thumb.jpg" alt="Measurement 4-5mm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample8/hypolophodon_sylvestris8_2.jpg" id="gallery-img-25">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_2_thumb.jpg" alt="Lateral view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample8/hypolophodon_sylvestris8_3.jpg" id="gallery-img-26">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_3_thumb.jpg" alt="Occlusal view, worn enameloid">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(9)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_1_thumb.jpg" alt="Measurement 5-6mm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_2_thumb.jpg" alt="Lateral view">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_3_thumb.jpg" alt="Lateral view">
-                                        </picture>
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-7" style="display: none;">
                                         
-                                        <div class="image-overlay">+2</div>
+                                        
+                                        <a href="../images/uk_collection/sample7/hypolophodon_sylvestris7_1.jpg" id="gallery-img-19">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_1_thumb.jpg" alt="Measurement 3-4mm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample7/hypolophodon_sylvestris7_2.jpg" id="gallery-img-20">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_2_thumb.jpg" alt="Occlusal view, hexagonal, worn enameloiod">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample7/hypolophodon_sylvestris7_3.jpg" id="gallery-img-21">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_3_thumb.jpg" alt="Lateral view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample7/hypolophodon_sylvestris7_4.jpg" id="gallery-img-22">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_4_thumb.jpg" alt="Lateral view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample7/hypolophodon_sylvestris7_5.jpg" id="gallery-img-23">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_5_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample7/thumbs_dir/hypolophodon_sylvestris7_5_thumb.jpg" alt="Root view">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(8)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_1_thumb.jpg" alt="Measurement 4-5mm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_2_thumb.jpg" alt="Lateral view">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_3_thumb.jpg" alt="Occlusal view, worn enameloid">
+                                                </picture>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-9" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample9/hypolophodon_sylvestris9_1.jpg" id="gallery-img-27">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_1_thumb.jpg" alt="Measurement 5-6mm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample9/hypolophodon_sylvestris9_2.jpg" id="gallery-img-28">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_2_thumb.jpg" alt="Lateral view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample9/hypolophodon_sylvestris9_3.jpg" id="gallery-img-29">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_3_thumb.jpg" alt="Lateral view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample9/hypolophodon_sylvestris9_4.jpg" id="gallery-img-30">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_4_thumb.jpg" alt="Occlusal view, worn enameloid">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample9/hypolophodon_sylvestris9_5.jpg" id="gallery-img-31">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_5_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_5_thumb.jpg" alt="Root view">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(10)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_1_thumb.jpg" alt="Anterior tooth. Measurement 1.3cm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_2_thumb.jpg" alt="Lingual view, striations visible">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_3_thumb.jpg" alt="Labial view">
-                                        </picture>
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-8" style="display: none;">
                                         
-                                        <div class="image-overlay">+2</div>
+                                        
+                                        <a href="../images/uk_collection/sample8/hypolophodon_sylvestris8_1.jpg" id="gallery-img-24">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_1_thumb.jpg" alt="Measurement 4-5mm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample8/hypolophodon_sylvestris8_2.jpg" id="gallery-img-25">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_2_thumb.jpg" alt="Lateral view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample8/hypolophodon_sylvestris8_3.jpg" id="gallery-img-26">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample8/thumbs_dir/hypolophodon_sylvestris8_3_thumb.jpg" alt="Occlusal view, worn enameloid">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(9)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_1_thumb.jpg" alt="Measurement 5-6mm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_2_thumb.jpg" alt="Lateral view">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_3_thumb.jpg" alt="Lateral view">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+2</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-10" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample10/sylvestrilamia_teretidens10_1.jpg" id="gallery-img-32">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_1_thumb.jpg" alt="Anterior tooth. Measurement 1.3cm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample10/sylvestrilamia_teretidens10_2.jpg" id="gallery-img-33">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_2_thumb.jpg" alt="Lingual view, striations visible">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample10/sylvestrilamia_teretidens10_3.jpg" id="gallery-img-34">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_3_thumb.jpg" alt="Labial view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample10/sylvestrilamia_teretidens10_4.jpg" id="gallery-img-35">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_4_thumb.jpg" alt="Lateral view, The sigmoidal curve of the tooth is visible.">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample10/sylvestrilamia_teretidens10_5.jpg" id="gallery-img-36">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_5_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_5_thumb.jpg" alt="Labial view with cusplet under microscope. The cutting edge extends to the cusplet.">
-                                    </picture>
-                                </a>
-                                
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-9" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample9/hypolophodon_sylvestris9_1.jpg" id="gallery-img-27">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_1_thumb.jpg" alt="Measurement 5-6mm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample9/hypolophodon_sylvestris9_2.jpg" id="gallery-img-28">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_2_thumb.jpg" alt="Lateral view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample9/hypolophodon_sylvestris9_3.jpg" id="gallery-img-29">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_3_thumb.jpg" alt="Lateral view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample9/hypolophodon_sylvestris9_4.jpg" id="gallery-img-30">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_4_thumb.jpg" alt="Occlusal view, worn enameloid">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample9/hypolophodon_sylvestris9_5.jpg" id="gallery-img-31">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_5_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample9/thumbs_dir/hypolophodon_sylvestris9_5_thumb.jpg" alt="Root view">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
                             </div>
+                            
                         </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(11)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_1_thumb.jpg" alt="Anterior tooth. Measurement 3.6cm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_2_thumb.jpg" alt="Lingual view">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_3_thumb.jpg" alt="Worn striations under microscope">
-                                        </picture>
-                                        
-                                        <div class="image-overlay">+1</div>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-11" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample11/striatolamia_macrota11_1.jpg" id="gallery-img-37">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_1_thumb.jpg" alt="Anterior tooth. Measurement 3.6cm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample11/striatolamia_macrota11_2.jpg" id="gallery-img-38">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_2_thumb.jpg" alt="Lingual view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample11/striatolamia_macrota11_3.jpg" id="gallery-img-39">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_3_thumb.jpg" alt="Worn striations under microscope">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample11/striatolamia_macrota11_4.jpg" id="gallery-img-40">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_4_thumb.jpg" alt="Cusplet and striations under a microscope.">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(12)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_1_thumb.jpg" alt="Anterior tooth. Measurement 3.3cm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_2_thumb.jpg" alt="Lingual view, striations visible">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_3_thumb.jpg" alt="Labial view">
-                                        </picture>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-12" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample12/striatolamia_macrota12_1.jpg" id="gallery-img-41">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_1_thumb.jpg" alt="Anterior tooth. Measurement 3.3cm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample12/striatolamia_macrota12_2.jpg" id="gallery-img-42">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_2_thumb.jpg" alt="Lingual view, striations visible">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample12/striatolamia_macrota12_3.jpg" id="gallery-img-43">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_3_thumb.jpg" alt="Labial view">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(13)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_1_thumb.jpg" alt="Lateral tooth. Measurement 1.8cm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_2_thumb.jpg" alt="Labial view">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_3_thumb.jpg" alt="Lingual view, faint striations">
-                                        </picture>
-                                        
-                                        <div class="image-overlay">+2</div>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-13" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample13/striatolamia_macrota13_1.jpg" id="gallery-img-44">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_1_thumb.jpg" alt="Lateral tooth. Measurement 1.8cm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample13/striatolamia_macrota13_2.jpg" id="gallery-img-45">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_2_thumb.jpg" alt="Labial view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample13/striatolamia_macrota13_3.jpg" id="gallery-img-46">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_3_thumb.jpg" alt="Lingual view, faint striations">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample13/striatolamia_macrota13_4.jpg" id="gallery-img-47">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_4_thumb.jpg" alt="Cusplets under a microscope, labial view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample13/striatolamia_macrota13_5.jpg" id="gallery-img-48">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_5_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_5_thumb.jpg" alt="Cusplet and striations under a microscope, lingual view">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(14)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_1_thumb.jpg" alt="Tooth. Measurement 7-8mm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_2_thumb.jpg" alt="The characteristic white tip of the tooth can be seen">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_3_thumb.jpg" alt="The hollow bottom of the tooth is visible">
-                                        </picture>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-14" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample14/lepisosteus_fimbriatus14_1.jpg" id="gallery-img-49">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_1_thumb.jpg" alt="Tooth. Measurement 7-8mm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample14/lepisosteus_fimbriatus14_2.jpg" id="gallery-img-50">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_2_thumb.jpg" alt="The characteristic white tip of the tooth can be seen">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample14/lepisosteus_fimbriatus14_3.jpg" id="gallery-img-51">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_3_thumb.jpg" alt="The hollow bottom of the tooth is visible">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(15)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_1_thumb.jpg" alt="Scale. Measurement 8-9mm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_2_thumb.jpg" alt="The scale looks leaf-shaped">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_3_thumb.jpg" alt="Back side">
-                                        </picture>
-                                        
-                                        <div class="image-overlay">+1</div>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-15" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample15/lepisosteus_fimbriatus15_1.jpg" id="gallery-img-52">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_1_thumb.jpg" alt="Scale. Measurement 8-9mm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample15/lepisosteus_fimbriatus15_2.jpg" id="gallery-img-53">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_2_thumb.jpg" alt="The scale looks leaf-shaped">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample15/lepisosteus_fimbriatus15_3.jpg" id="gallery-img-54">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_3_thumb.jpg" alt="Back side">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample15/lepisosteus_fimbriatus15_4.jpg" id="gallery-img-55">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_4_thumb.jpg" alt="View under a microscope, (?)ornamentation visible">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(16)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_1_thumb.jpg" alt="Scale fragment. Measurement 12-13mm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_2_thumb.jpg" alt="The scale looks fragmented">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_3_thumb.jpg" alt="Back side">
-                                        </picture>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-16" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample16/lepisosteus_fimbriatus16_1.jpg" id="gallery-img-56">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_1_thumb.jpg" alt="Scale fragment. Measurement 12-13mm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample16/lepisosteus_fimbriatus16_2.jpg" id="gallery-img-57">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_2_thumb.jpg" alt="The scale looks fragmented">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample16/lepisosteus_fimbriatus16_3.jpg" id="gallery-img-58">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_3_thumb.jpg" alt="Back side">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(17)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_1_thumb.jpg" alt="Measurement 3-4mm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_2_thumb.jpg" alt="Ventral view">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_3_thumb.jpg" alt="Dorsal view">
-                                        </picture>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-17" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample17/theodoxus_pisiformis17_1.jpg" id="gallery-img-59">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_1_thumb.jpg" alt="Measurement 3-4mm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample17/theodoxus_pisiformis17_2.jpg" id="gallery-img-60">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_2_thumb.jpg" alt="Ventral view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample17/theodoxus_pisiformis17_3.jpg" id="gallery-img-61">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_3_thumb.jpg" alt="Dorsal view">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(18)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_1_thumb.jpg" alt="Measurement 5-6mm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_2_thumb.jpg" alt="Ventral view">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_3_thumb.jpg" alt="Dorsal view">
-                                        </picture>
-                                        
-                                        <div class="image-overlay">+1</div>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-18" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample18/theodoxus_pisiformis18_1.jpg" id="gallery-img-62">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_1_thumb.jpg" alt="Measurement 5-6mm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample18/theodoxus_pisiformis18_2.jpg" id="gallery-img-63">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_2_thumb.jpg" alt="Ventral view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample18/theodoxus_pisiformis18_3.jpg" id="gallery-img-64">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_3_thumb.jpg" alt="Dorsal view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample18/theodoxus_pisiformis18_4.jpg" id="gallery-img-65">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_4_thumb.jpg" alt="Dorsal view">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(19)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_1_thumb.jpg" alt="Measurement 5-6mm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_2_thumb.jpg" alt="Ventral view">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_3_thumb.jpg" alt="Dorsal view">
-                                        </picture>
-                                        
-                                        <div class="image-overlay">+1</div>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-19" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample19/theodoxus_pisiformis19_1.jpg" id="gallery-img-66">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_1_thumb.jpg" alt="Measurement 5-6mm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample19/theodoxus_pisiformis19_2.jpg" id="gallery-img-67">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_2_thumb.jpg" alt="Ventral view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample19/theodoxus_pisiformis19_3.jpg" id="gallery-img-68">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_3_thumb.jpg" alt="Dorsal view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample19/theodoxus_pisiformis19_4.jpg" id="gallery-img-69">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_4_thumb.jpg" alt="Dorsal view">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(20)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_1_thumb.jpg" alt="Measurement 4-5mm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_2_thumb.jpg" alt="Dorsal view">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_3_thumb.jpg" alt="Dorsal view">
-                                        </picture>
-                                        
-                                        <div class="image-overlay">+2</div>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-20" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample20/theodoxus_pisiformis20_1.jpg" id="gallery-img-70">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_1_thumb.jpg" alt="Measurement 4-5mm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample20/theodoxus_pisiformis20_2.jpg" id="gallery-img-71">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_2_thumb.jpg" alt="Dorsal view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample20/theodoxus_pisiformis20_3.jpg" id="gallery-img-72">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_3_thumb.jpg" alt="Dorsal view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample20/theodoxus_pisiformis20_4.jpg" id="gallery-img-73">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_4_thumb.jpg" alt="Ventral view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample20/theodoxus_pisiformis20_5.jpg" id="gallery-img-74">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_5_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_5_thumb.jpg" alt="Ventral view">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
                     </div>
-                </div>
-            </section>
-        </main>
+                </section>
+                <section id="abbey-wood-lepisosteus_fimbriatus-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/chordata/osteichthyes/actinopterygii/lepisosteidae/lepisosteus/lepisosteus_fimbriatus/lepisosteus_fimbriatus.html" style="text-decoration: none;">
+                            <h1 id="lepisosteus_fimbriatus"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/chordata/osteichthyes/actinopterygii/lepisosteidae/lepisosteus/lepisosteus_fimbriatus/lepisosteus_fimbriatus.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%9B%CE%B5%CF%80%CE%B9%CE%B4%CF%8C%CF%83%CF%84%CE%B5%CE%BF%CF%82%20%CE%BF%20%CE%BA%CF%81%CE%BF%CF%83%CF%83%CF%89%CF%84%CF%8C%CF%82.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Λεπιδόστεος ο κροσσωτός.jpg" alt="Artistic depiction of Lepisosteus fimbriatus" id="abbey-wood-lepisosteus_fimbriatus-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(10)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_1_thumb.jpg" alt="Tooth. Measurement 7-8mm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_2_thumb.jpg" alt="The characteristic white tip of the tooth can be seen">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_3_thumb.jpg" alt="The hollow bottom of the tooth is visible">
+                                                </picture>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-10" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample14/lepisosteus_fimbriatus14_1.jpg" id="gallery-img-32">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_1_thumb.jpg" alt="Tooth. Measurement 7-8mm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample14/lepisosteus_fimbriatus14_2.jpg" id="gallery-img-33">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_2_thumb.jpg" alt="The characteristic white tip of the tooth can be seen">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample14/lepisosteus_fimbriatus14_3.jpg" id="gallery-img-34">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample14/thumbs_dir/lepisosteus_fimbriatus14_3_thumb.jpg" alt="The hollow bottom of the tooth is visible">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(11)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_1_thumb.jpg" alt="Scale. Measurement 8-9mm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_2_thumb.jpg" alt="The scale looks leaf-shaped">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_3_thumb.jpg" alt="Back side">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+1</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-11" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample15/lepisosteus_fimbriatus15_1.jpg" id="gallery-img-35">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_1_thumb.jpg" alt="Scale. Measurement 8-9mm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample15/lepisosteus_fimbriatus15_2.jpg" id="gallery-img-36">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_2_thumb.jpg" alt="The scale looks leaf-shaped">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample15/lepisosteus_fimbriatus15_3.jpg" id="gallery-img-37">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_3_thumb.jpg" alt="Back side">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample15/lepisosteus_fimbriatus15_4.jpg" id="gallery-img-38">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample15/thumbs_dir/lepisosteus_fimbriatus15_4_thumb.jpg" alt="View under a microscope, (?)ornamentation visible">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(12)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_1_thumb.jpg" alt="Scale fragment. Measurement 12-13mm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_2_thumb.jpg" alt="The scale looks fragmented">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_3_thumb.jpg" alt="Back side">
+                                                </picture>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-12" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample16/lepisosteus_fimbriatus16_1.jpg" id="gallery-img-39">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_1_thumb.jpg" alt="Scale fragment. Measurement 12-13mm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample16/lepisosteus_fimbriatus16_2.jpg" id="gallery-img-40">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_2_thumb.jpg" alt="The scale looks fragmented">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample16/lepisosteus_fimbriatus16_3.jpg" id="gallery-img-41">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample16/thumbs_dir/lepisosteus_fimbriatus16_3_thumb.jpg" alt="Back side">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                <section id="abbey-wood-striatolamia_macrota-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/chordata/chondrichthyes/elasmobranchii/odontaspididae/striatolamia/striatolamia_macrota/striatolamia_macrota.html" style="text-decoration: none;">
+                            <h1 id="striatolamia_macrota"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/chordata/chondrichthyes/elasmobranchii/odontaspididae/striatolamia/striatolamia_macrota/striatolamia_macrota.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%A3%CF%84%CF%81%CE%B9%CE%B1%CF%84%CE%BF%CE%BB%CE%AC%CE%BC%CE%B9%CE%B1%20%CE%B7%20%CE%BC%CE%B1%CE%BA%CF%81%CE%AC.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Στριατολάμια η μακρά.jpg" alt="Artistic depiction of Striatolamia macrota" id="abbey-wood-striatolamia_macrota-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(13)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_1_thumb.jpg" alt="Anterior tooth. Measurement 3.6cm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_2_thumb.jpg" alt="Lingual view">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_3_thumb.jpg" alt="Worn striations under microscope">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+1</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-13" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample11/striatolamia_macrota11_1.jpg" id="gallery-img-42">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_1_thumb.jpg" alt="Anterior tooth. Measurement 3.6cm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample11/striatolamia_macrota11_2.jpg" id="gallery-img-43">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_2_thumb.jpg" alt="Lingual view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample11/striatolamia_macrota11_3.jpg" id="gallery-img-44">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_3_thumb.jpg" alt="Worn striations under microscope">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample11/striatolamia_macrota11_4.jpg" id="gallery-img-45">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample11/thumbs_dir/striatolamia_macrota11_4_thumb.jpg" alt="Cusplet and striations under a microscope.">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(14)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_1_thumb.jpg" alt="Anterior tooth. Measurement 3.3cm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_2_thumb.jpg" alt="Lingual view, striations visible">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_3_thumb.jpg" alt="Labial view">
+                                                </picture>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-14" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample12/striatolamia_macrota12_1.jpg" id="gallery-img-46">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_1_thumb.jpg" alt="Anterior tooth. Measurement 3.3cm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample12/striatolamia_macrota12_2.jpg" id="gallery-img-47">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_2_thumb.jpg" alt="Lingual view, striations visible">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample12/striatolamia_macrota12_3.jpg" id="gallery-img-48">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample12/thumbs_dir/striatolamia_macrota12_3_thumb.jpg" alt="Labial view">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(15)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_1_thumb.jpg" alt="Lateral tooth. Measurement 1.8cm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_2_thumb.jpg" alt="Labial view">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_3_thumb.jpg" alt="Lingual view, faint striations">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+2</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-15" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample13/striatolamia_macrota13_1.jpg" id="gallery-img-49">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_1_thumb.jpg" alt="Lateral tooth. Measurement 1.8cm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample13/striatolamia_macrota13_2.jpg" id="gallery-img-50">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_2_thumb.jpg" alt="Labial view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample13/striatolamia_macrota13_3.jpg" id="gallery-img-51">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_3_thumb.jpg" alt="Lingual view, faint striations">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample13/striatolamia_macrota13_4.jpg" id="gallery-img-52">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_4_thumb.jpg" alt="Cusplets under a microscope, labial view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample13/striatolamia_macrota13_5.jpg" id="gallery-img-53">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_5_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample13/thumbs_dir/striatolamia_macrota13_5_thumb.jpg" alt="Cusplet and striations under a microscope, lingual view">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                <section id="abbey-wood-sylvestrilamia_teretidens-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/chordata/chondrichthyes/elasmobranchii/odontaspididae/sylvestrilamia/sylvestrilamia_teretidens/sylvestrilamia_teretidens.html" style="text-decoration: none;">
+                            <h1 id="sylvestrilamia_teretidens"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/chordata/chondrichthyes/elasmobranchii/odontaspididae/sylvestrilamia/sylvestrilamia_teretidens/sylvestrilamia_teretidens.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%A3%CF%85%CE%BB%CE%B2%CE%B5%CF%83%CF%84%CF%81%CE%B9%CE%BB%CE%AC%CE%BC%CE%B9%CE%B1%20%CE%B7%20%CE%BB%CE%B5%CE%B9%CF%8C%CE%B4%CE%BF%CF%85%CF%82.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Συλβεστριλάμια η λειόδους.jpg" alt="Artistic depiction of Sylvestrilamia teretidens" id="abbey-wood-sylvestrilamia_teretidens-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(16)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_1_thumb.jpg" alt="Anterior tooth. Measurement 1.3cm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_2_thumb.jpg" alt="Lingual view, striations visible">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_3_thumb.jpg" alt="Labial view">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+2</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-16" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample10/sylvestrilamia_teretidens10_1.jpg" id="gallery-img-54">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_1_thumb.jpg" alt="Anterior tooth. Measurement 1.3cm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample10/sylvestrilamia_teretidens10_2.jpg" id="gallery-img-55">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_2_thumb.jpg" alt="Lingual view, striations visible">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample10/sylvestrilamia_teretidens10_3.jpg" id="gallery-img-56">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_3_thumb.jpg" alt="Labial view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample10/sylvestrilamia_teretidens10_4.jpg" id="gallery-img-57">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_4_thumb.jpg" alt="Lateral view, The sigmoidal curve of the tooth is visible.">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample10/sylvestrilamia_teretidens10_5.jpg" id="gallery-img-58">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_5_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample10/thumbs_dir/sylvestrilamia_teretidens10_5_thumb.jpg" alt="Labial view with cusplet under microscope. The cutting edge extends to the cusplet.">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                <section id="abbey-wood-theodoxus_pisiformis-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/mollusca/gastropoda/neritimorpha/neritidae/theodoxus/theodoxus_pisiformis/theodoxus_pisiformis.html" style="text-decoration: none;">
+                            <h1 id="theodoxus_pisiformis"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/mollusca/gastropoda/neritimorpha/neritidae/theodoxus/theodoxus_pisiformis/theodoxus_pisiformis.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%98%CE%B5%CF%8C%CE%B4%CE%BF%CE%BE%CE%BF%CF%82%20%CE%BF%20%CF%80%CE%B9%CF%83%CF%8C%CE%BC%CE%BF%CF%81%CF%86%CE%BF%CF%82.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Θεόδοξος ο πισόμορφος.jpg" alt="Artistic depiction of Theodoxus pisiformis" id="abbey-wood-theodoxus_pisiformis-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(17)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_1_thumb.jpg" alt="Measurement 3-4mm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_2_thumb.jpg" alt="Ventral view">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_3_thumb.jpg" alt="Dorsal view">
+                                                </picture>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-17" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample17/theodoxus_pisiformis17_1.jpg" id="gallery-img-59">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_1_thumb.jpg" alt="Measurement 3-4mm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample17/theodoxus_pisiformis17_2.jpg" id="gallery-img-60">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_2_thumb.jpg" alt="Ventral view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample17/theodoxus_pisiformis17_3.jpg" id="gallery-img-61">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample17/thumbs_dir/theodoxus_pisiformis17_3_thumb.jpg" alt="Dorsal view">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(18)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_1_thumb.jpg" alt="Measurement 5-6mm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_2_thumb.jpg" alt="Ventral view">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_3_thumb.jpg" alt="Dorsal view">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+1</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-18" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample18/theodoxus_pisiformis18_1.jpg" id="gallery-img-62">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_1_thumb.jpg" alt="Measurement 5-6mm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample18/theodoxus_pisiformis18_2.jpg" id="gallery-img-63">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_2_thumb.jpg" alt="Ventral view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample18/theodoxus_pisiformis18_3.jpg" id="gallery-img-64">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_3_thumb.jpg" alt="Dorsal view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample18/theodoxus_pisiformis18_4.jpg" id="gallery-img-65">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample18/thumbs_dir/theodoxus_pisiformis18_4_thumb.jpg" alt="Dorsal view">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(19)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_1_thumb.jpg" alt="Measurement 5-6mm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_2_thumb.jpg" alt="Ventral view">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_3_thumb.jpg" alt="Dorsal view">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+1</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-19" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample19/theodoxus_pisiformis19_1.jpg" id="gallery-img-66">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_1_thumb.jpg" alt="Measurement 5-6mm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample19/theodoxus_pisiformis19_2.jpg" id="gallery-img-67">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_2_thumb.jpg" alt="Ventral view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample19/theodoxus_pisiformis19_3.jpg" id="gallery-img-68">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_3_thumb.jpg" alt="Dorsal view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample19/theodoxus_pisiformis19_4.jpg" id="gallery-img-69">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample19/thumbs_dir/theodoxus_pisiformis19_4_thumb.jpg" alt="Dorsal view">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(20)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_1_thumb.jpg" alt="Measurement 4-5mm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_2_thumb.jpg" alt="Dorsal view">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_3_thumb.jpg" alt="Dorsal view">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+2</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-20" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample20/theodoxus_pisiformis20_1.jpg" id="gallery-img-70">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_1_thumb.jpg" alt="Measurement 4-5mm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample20/theodoxus_pisiformis20_2.jpg" id="gallery-img-71">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_2_thumb.jpg" alt="Dorsal view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample20/theodoxus_pisiformis20_3.jpg" id="gallery-img-72">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_3_thumb.jpg" alt="Dorsal view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample20/theodoxus_pisiformis20_4.jpg" id="gallery-img-73">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_4_thumb.jpg" alt="Ventral view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample20/theodoxus_pisiformis20_5.jpg" id="gallery-img-74">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_5_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample20/thumbs_dir/theodoxus_pisiformis20_5_thumb.jpg" alt="Ventral view">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                </main>
     </div>
 
     <footer>
@@ -1341,7 +1464,7 @@
         id="language-script"
         src="../scripts/language.js"
         dict="/localities/abbey-wood.json"
-        keys="τίτλος,abbey-wood,abbey-wood-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,abbey-wood-formation,abbey-wood-depositional_environment,abbey-wood-fossil_types,abbey-wood-paleoecology_highlights,lower,eocene,mya,longshore-drift-description"
+        keys="τίτλος,abbey-wood,abbey-wood-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,abbey-wood-formation,abbey-wood-depositional_environment,abbey-wood-fossil_types,abbey-wood-paleoecology_highlights,lower,eocene,hypolophodon_sylvestris,sylvestrilamia_teretidens,striatolamia_macrota,lepisosteus_fimbriatus,theodoxus_pisiformis,mya"
         galleryLength="74"
     ></script>
 

--- a/localities/alassa.html
+++ b/localities/alassa.html
@@ -57,1307 +57,1691 @@
                 </div>
             </section>
 
-            <section id="alassa-gallery">
-                <div class="tax-subcontainer">
-                    <div class="gallery" id="gallery-">
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(1)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample2/thumbs_dir/U2_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample2/thumbs_dir/U2_1_thumb.jpg" alt="Unknown">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-1" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample2/U2_1.jpg" id="gallery-img-1">
+            <section id="alassa-actinopterygii-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/chordata/osteichthyes/actinopterygii/actinopterygii.html" style="text-decoration: none;">
+                            <h1 id="actinopterygii"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/chordata/osteichthyes/actinopterygii/actinopterygii.html">
                                     <picture>
-                                        <source srcset="../images/cy_collection/sample2/thumbs_dir/U2_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample2/thumbs_dir/U2_1_thumb.jpg" alt="Unknown">
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%91%CE%BA%CF%84%CE%B9%CE%BD%CE%BF%CF%80%CF%84%CE%B5%CF%81%CF%8D%CE%B3%CE%B9%CE%BF%CE%B9.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Ακτινοπτερύγιοι.jpg" alt="Artistic depiction of Actinopterygii" id="alassa-actinopterygii-εικόνα">
                                     </picture>
                                 </a>
-                                
                             </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(2)">
                             
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample5/thumbs_dir/U5_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample5/thumbs_dir/U5_1_thumb.jpg" alt="Leaf">
-                            </picture>
                             
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-2" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample5/U5_1.jpg" id="gallery-img-2">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample5/thumbs_dir/U5_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample5/thumbs_dir/U5_1_thumb.jpg" alt="Leaf">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(3)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample7/thumbs_dir/U7_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample7/thumbs_dir/U7_1_thumb.jpg" alt="Unknown fish - before cleaning">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample7/thumbs_dir/U7_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample7/thumbs_dir/U7_2_thumb.jpg" alt="Unknown fish">
-                                        </picture>
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(1)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample7/thumbs_dir/U7_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample7/thumbs_dir/U7_1_thumb.jpg" alt="Unknown fish - before cleaning">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample7/thumbs_dir/U7_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample7/thumbs_dir/U7_2_thumb.jpg" alt="Unknown fish">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample7/thumbs_dir/U7_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample7/thumbs_dir/U7_3_thumb.jpg" alt="Unknown fish - body detail">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+1</div>
+                                                
+                                            </div>
+                                        </div>
                                     </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample7/thumbs_dir/U7_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample7/thumbs_dir/U7_3_thumb.jpg" alt="Unknown fish - body detail">
-                                        </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-1" style="display: none;">
                                         
-                                        <div class="image-overlay">+1</div>
+                                        
+                                        <a href="../images/cy_collection/sample7/U7_1.jpg" id="gallery-img-1">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample7/thumbs_dir/U7_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample7/thumbs_dir/U7_1_thumb.jpg" alt="Unknown fish - before cleaning">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample7/U7_2.jpg" id="gallery-img-2">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample7/thumbs_dir/U7_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample7/thumbs_dir/U7_2_thumb.jpg" alt="Unknown fish">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample7/U7_3.jpg" id="gallery-img-3">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample7/thumbs_dir/U7_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample7/thumbs_dir/U7_3_thumb.jpg" alt="Unknown fish - body detail">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample7/U7_4.jpg" id="gallery-img-4">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample7/thumbs_dir/U7_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample7/thumbs_dir/U7_4_thumb.jpg" alt="Unknown fish - tail detail">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-3" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample7/U7_1.jpg" id="gallery-img-3">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample7/thumbs_dir/U7_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample7/thumbs_dir/U7_1_thumb.jpg" alt="Unknown fish - before cleaning">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample7/U7_2.jpg" id="gallery-img-4">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample7/thumbs_dir/U7_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample7/thumbs_dir/U7_2_thumb.jpg" alt="Unknown fish">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample7/U7_3.jpg" id="gallery-img-5">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample7/thumbs_dir/U7_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample7/thumbs_dir/U7_3_thumb.jpg" alt="Unknown fish - body detail">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample7/U7_4.jpg" id="gallery-img-6">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample7/thumbs_dir/U7_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample7/thumbs_dir/U7_4_thumb.jpg" alt="Unknown fish - tail detail">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(4)">
                             
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample8/thumbs_dir/U8_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample8/thumbs_dir/U8_1_thumb.jpg" alt="Spine and (?)fins">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-4" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample8/U8_1.jpg" id="gallery-img-7">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample8/thumbs_dir/U8_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample8/thumbs_dir/U8_1_thumb.jpg" alt="Spine and (?)fins">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(5)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample9/thumbs_dir/U9_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample9/thumbs_dir/U9_1_thumb.jpg" alt="Scale and (?)plant remains">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-5" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample9/U9_1.jpg" id="gallery-img-8">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample9/thumbs_dir/U9_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample9/thumbs_dir/U9_1_thumb.jpg" alt="Scale and (?)plant remains">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(6)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample10/thumbs_dir/U10_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample10/thumbs_dir/U10_1_thumb.jpg" alt="Spine and (?)head">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-6" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample10/U10_1.jpg" id="gallery-img-9">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample10/thumbs_dir/U10_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample10/thumbs_dir/U10_1_thumb.jpg" alt="Spine and (?)head">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(7)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample11/thumbs_dir/U11_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample11/thumbs_dir/U11_1_thumb.jpg" alt="Spine and (?)head">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-7" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample11/U11_1.jpg" id="gallery-img-10">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample11/thumbs_dir/U11_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample11/thumbs_dir/U11_1_thumb.jpg" alt="Spine and (?)head">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(8)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample12/thumbs_dir/U12_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample12/thumbs_dir/U12_1_thumb.jpg" alt="Spine and (?)part of body">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-8" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample12/U12_1.jpg" id="gallery-img-11">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample12/thumbs_dir/U12_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample12/thumbs_dir/U12_1_thumb.jpg" alt="Spine and (?)part of body">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(9)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample13/thumbs_dir/U13_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample13/thumbs_dir/U13_1_thumb.jpg" alt="Unknown fish">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-9" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample13/U13_1.jpg" id="gallery-img-12">
-                                    <picture>
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(2)">
+                                    
+                                    <picture class="image-single">
                                         <source srcset="../images/cy_collection/sample13/thumbs_dir/U13_1_thumb.webp 1x" type="image/webp">
                                         <img loading="lazy" src="../images/cy_collection/sample13/thumbs_dir/U13_1_thumb.jpg" alt="Unknown fish">
                                     </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(10)">
-                            
-                            <div class="image-two">
-                                <picture class="image-main">
-                                    <source srcset="../images/cy_collection/sample22/thumbs_dir/U22_1_thumb.webp 1x" type="image/webp">
-                                    <img loading="lazy" src="../images/cy_collection/sample22/thumbs_dir/U22_1_thumb.jpg" alt="In-situ, in a riverbed. Very eroded">
-                                </picture>
-                                <div class="image-overlay">+1</div>
-                            </div>
-                            
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-10" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample22/U22_1.jpg" id="gallery-img-13">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample22/thumbs_dir/U22_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample22/thumbs_dir/U22_1_thumb.jpg" alt="In-situ, in a riverbed. Very eroded">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample22/U22_2.jpg" id="gallery-img-14">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample22/thumbs_dir/U22_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample22/thumbs_dir/U22_2_thumb.jpg" alt="~8cm">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(11)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample23/thumbs_dir/U23_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample23/thumbs_dir/U23_1_thumb.jpg" alt="In-situ, inside the matrix">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample23/thumbs_dir/U23_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample23/thumbs_dir/U23_2_thumb.jpg" alt="After digging up">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample23/thumbs_dir/U23_3_done_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample23/thumbs_dir/U23_3_done_thumb.jpg" alt="The sample has been removed from the rock">
-                                        </picture>
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-2" style="display: none;">
                                         
-                                        <div class="image-overlay">+2</div>
+                                        
+                                        <a href="../images/cy_collection/sample13/U13_1.jpg" id="gallery-img-5">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample13/thumbs_dir/U13_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample13/thumbs_dir/U13_1_thumb.jpg" alt="Unknown fish">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-11" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample23/U23_1.jpg" id="gallery-img-15">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample23/thumbs_dir/U23_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample23/thumbs_dir/U23_1_thumb.jpg" alt="In-situ, inside the matrix">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample23/U23_2.jpg" id="gallery-img-16">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample23/thumbs_dir/U23_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample23/thumbs_dir/U23_2_thumb.jpg" alt="After digging up">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample23/U23_3_done.jpg" id="gallery-img-17">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample23/thumbs_dir/U23_3_done_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample23/thumbs_dir/U23_3_done_thumb.jpg" alt="The sample has been removed from the rock">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample23/U23_4.jpg" id="gallery-img-18">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample23/thumbs_dir/U23_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample23/thumbs_dir/U23_4_thumb.jpg" alt="Apical view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample23/U23_5.jpg" id="gallery-img-19">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample23/thumbs_dir/U23_5_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample23/thumbs_dir/U23_5_thumb.jpg" alt="Oral view">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(12)">
                             
-                            <div class="image-two">
-                                <picture class="image-main">
-                                    <source srcset="../images/cy_collection/sample25/thumbs_dir/U25_1_thumb.webp 1x" type="image/webp">
-                                    <img loading="lazy" src="../images/cy_collection/sample25/thumbs_dir/U25_1_thumb.jpg" alt="Scales (from a tail?)">
-                                </picture>
-                                <div class="image-overlay">+1</div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-12" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample25/U25_1.jpg" id="gallery-img-20">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample25/thumbs_dir/U25_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample25/thumbs_dir/U25_1_thumb.jpg" alt="Scales (from a tail?)">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample25/U25_2.jpg" id="gallery-img-21">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample25/thumbs_dir/U25_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample25/thumbs_dir/U25_2_thumb.jpg" alt="Detail">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(13)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample26/thumbs_dir/U26_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample26/thumbs_dir/U26_1_thumb.jpg" alt="Unknown fish">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-13" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample26/U26_1.jpg" id="gallery-img-22">
-                                    <picture>
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(3)">
+                                    
+                                    <picture class="image-single">
                                         <source srcset="../images/cy_collection/sample26/thumbs_dir/U26_1_thumb.webp 1x" type="image/webp">
                                         <img loading="lazy" src="../images/cy_collection/sample26/thumbs_dir/U26_1_thumb.jpg" alt="Unknown fish">
                                     </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(14)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample27/thumbs_dir/U27_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample27/thumbs_dir/U27_1_thumb.jpg" alt="Spine and (?)head">
-                            </picture>
-                            
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-14" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample27/U27_1.jpg" id="gallery-img-23">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample27/thumbs_dir/U27_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample27/thumbs_dir/U27_1_thumb.jpg" alt="Spine and (?)head">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(15)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_1_thumb.jpg" alt="Scales (of a fish?), elongated shape. 7 fragments">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_2_thumb.jpg" alt="3 large fragments">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_3_thumb.jpg" alt="Large fragments. Side Α">
-                                        </picture>
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-3" style="display: none;">
                                         
-                                        <div class="image-overlay">+6</div>
+                                        
+                                        <a href="../images/cy_collection/sample26/U26_1.jpg" id="gallery-img-6">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample26/thumbs_dir/U26_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample26/thumbs_dir/U26_1_thumb.jpg" alt="Unknown fish">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-15" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample28/U28_1.jpg" id="gallery-img-24">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_1_thumb.jpg" alt="Scales (of a fish?), elongated shape. 7 fragments">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample28/U28_2.jpg" id="gallery-img-25">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_2_thumb.jpg" alt="3 large fragments">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample28/U28_3.jpg" id="gallery-img-26">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_3_thumb.jpg" alt="Large fragments. Side Α">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample28/U28_4.jpg" id="gallery-img-27">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_4_thumb.jpg" alt="Large fragment. Side B">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample28/U28_5.jpg" id="gallery-img-28">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_5_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_5_thumb.jpg" alt="Small fragments">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample28/U28_6.jpg" id="gallery-img-29">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_6_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_6_thumb.jpg" alt="Small fragment A, detail">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample28/U28_7.jpg" id="gallery-img-30">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_7_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_7_thumb.jpg" alt="Small fragment B, detail">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample28/U28_8.jpg" id="gallery-img-31">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_8_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_8_thumb.jpg" alt="Small fragment C, detail">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample28/U28_9.jpg" id="gallery-img-32">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_9_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_9_thumb.jpg" alt="Small fragment D, detail">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(16)">
                             
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample29/thumbs_dir/U29_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample29/thumbs_dir/U29_1_thumb.jpg" alt="Plant(?) - perhaps Posidonia oceanica?">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-16" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample29/U29_1.jpg" id="gallery-img-33">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample29/thumbs_dir/U29_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample29/thumbs_dir/U29_1_thumb.jpg" alt="Plant(?) - perhaps Posidonia oceanica?">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(17)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample30/thumbs_dir/U30_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample30/thumbs_dir/U30_1_thumb.jpg" alt="3-4 shells. One likely of the genus Venus">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-17" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample30/U30_1.jpg" id="gallery-img-34">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample30/thumbs_dir/U30_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample30/thumbs_dir/U30_1_thumb.jpg" alt="3-4 shells. One likely of the genus Venus">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(18)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample31/thumbs_dir/U31_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample31/thumbs_dir/U31_1_thumb.jpg" alt="Spine and (?)head">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-18" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample31/U31_1.jpg" id="gallery-img-35">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample31/thumbs_dir/U31_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample31/thumbs_dir/U31_1_thumb.jpg" alt="Spine and (?)head">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(19)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_1_thumb.jpg" alt="Conical impressions.">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_2_thumb.jpg" alt="Conical impressions.">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_3_thumb.jpg" alt="Conical impressions.">
-                                        </picture>
-                                        
-                                        <div class="image-overlay">+4</div>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-19" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample32/U32_1.jpg" id="gallery-img-36">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_1_thumb.jpg" alt="Conical impressions.">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample32/U32_2.jpg" id="gallery-img-37">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_2_thumb.jpg" alt="Conical impressions.">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample32/U32_3.jpg" id="gallery-img-38">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_3_thumb.jpg" alt="Conical impressions.">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample32/U32_4.jpg" id="gallery-img-39">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_4_thumb.jpg" alt="Conical impressions.">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample32/U32_5.jpg" id="gallery-img-40">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_5_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_5_thumb.jpg" alt="Conical impressions.">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample32/U32_6.jpg" id="gallery-img-41">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_6_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_6_thumb.jpg" alt="Conical impressions.">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample32/U32_7.jpg" id="gallery-img-42">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_7_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_7_thumb.jpg" alt="Conical impressions.">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(20)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample33/thumbs_dir/U33_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample33/thumbs_dir/U33_1_thumb.jpg" alt="Scales">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-20" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample33/U33_1.jpg" id="gallery-img-43">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample33/thumbs_dir/U33_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample33/thumbs_dir/U33_1_thumb.jpg" alt="Scales">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(21)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample34/thumbs_dir/U34_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample34/thumbs_dir/U34_1_thumb.jpg" alt="Fish">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-21" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample34/U34_1.jpg" id="gallery-img-44">
-                                    <picture>
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(4)">
+                                    
+                                    <picture class="image-single">
                                         <source srcset="../images/cy_collection/sample34/thumbs_dir/U34_1_thumb.webp 1x" type="image/webp">
                                         <img loading="lazy" src="../images/cy_collection/sample34/thumbs_dir/U34_1_thumb.jpg" alt="Fish">
                                     </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(22)">
-                            
-                            <div class="image-two">
-                                <picture class="image-main">
-                                    <source srcset="../images/cy_collection/sample35/thumbs_dir/U35_1_thumb.webp 1x" type="image/webp">
-                                    <img loading="lazy" src="../images/cy_collection/sample35/thumbs_dir/U35_1_thumb.jpg" alt="Scale">
-                                </picture>
-                                <div class="image-overlay">+1</div>
-                            </div>
-                            
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-22" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample35/U35_1.jpg" id="gallery-img-45">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample35/thumbs_dir/U35_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample35/thumbs_dir/U35_1_thumb.jpg" alt="Scale">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample35/U35_2.jpg" id="gallery-img-46">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample35/thumbs_dir/U35_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample35/thumbs_dir/U35_2_thumb.jpg" alt="Detail">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(23)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample36/thumbs_dir/U36_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample36/thumbs_dir/U36_1_thumb.jpg" alt="Pre-preparation">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample36/thumbs_dir/U36_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample36/thumbs_dir/U36_2_thumb.jpg" alt="Radiating lines are visible">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample36/thumbs_dir/U36_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample36/thumbs_dir/U36_3_thumb.jpg" alt="Radiating lines are visible">
-                                        </picture>
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-4" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample34/U34_1.jpg" id="gallery-img-7">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample34/thumbs_dir/U34_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample34/thumbs_dir/U34_1_thumb.jpg" alt="Fish">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-23" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample36/U36_1.jpg" id="gallery-img-47">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample36/thumbs_dir/U36_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample36/thumbs_dir/U36_1_thumb.jpg" alt="Pre-preparation">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample36/U36_2.jpg" id="gallery-img-48">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample36/thumbs_dir/U36_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample36/thumbs_dir/U36_2_thumb.jpg" alt="Radiating lines are visible">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample36/U36_3.jpg" id="gallery-img-49">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample36/thumbs_dir/U36_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample36/thumbs_dir/U36_3_thumb.jpg" alt="Radiating lines are visible">
-                                    </picture>
-                                </a>
-                                
-                            </div>
                         </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(24)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
+                    </div>
+                </section>
+                <section id="alassa-aves-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/chordata/osteichthyes/sarcopterygii/sauropsida/dinosauria/theropoda/aves/aves.html" style="text-decoration: none;">
+                            <h1 id="aves"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/chordata/osteichthyes/sarcopterygii/sauropsida/dinosauria/theropoda/aves/aves.html">
                                     <picture>
-                                        <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_1_thumb.jpg" alt="">
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%A0%CF%84%CE%B7%CE%BD%CE%AC.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Πτηνά.jpg" alt="Artistic depiction of Aves" id="alassa-aves-εικόνα">
                                     </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_2_thumb.jpg" alt="Unclear detail with spine - perhaps a fish head">
-                                        </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(5)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample38/thumbs_dir/U38_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample38/thumbs_dir/U38_1_thumb.jpg" alt="Pre-preparation">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample38/thumbs_dir/U38_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample38/thumbs_dir/U38_2_thumb.jpg" alt="Prepared. Bird(?)">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample38/thumbs_dir/U38_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample38/thumbs_dir/U38_3_thumb.jpg" alt="Damaged (by preparation)">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+1</div>
+                                                
+                                            </div>
+                                        </div>
                                     </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_3_thumb.jpg" alt="">
-                                        </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-5" style="display: none;">
                                         
+                                        
+                                        <a href="../images/cy_collection/sample38/U38_1.jpg" id="gallery-img-8">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample38/thumbs_dir/U38_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample38/thumbs_dir/U38_1_thumb.jpg" alt="Pre-preparation">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample38/U38_2.jpg" id="gallery-img-9">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample38/thumbs_dir/U38_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample38/thumbs_dir/U38_2_thumb.jpg" alt="Prepared. Bird(?)">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample38/U38_3.jpg" id="gallery-img-10">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample38/thumbs_dir/U38_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample38/thumbs_dir/U38_3_thumb.jpg" alt="Damaged (by preparation)">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample38/U38_4.jpg" id="gallery-img-11">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample38/thumbs_dir/U38_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample38/thumbs_dir/U38_4_thumb.jpg" alt="Damaged (by washing)">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                <section id="alassa-bivalvia-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/mollusca/bivalvia/bivalvia.html" style="text-decoration: none;">
+                            <h1 id="bivalvia"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/mollusca/bivalvia/bivalvia.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%94%CE%AF%CE%B8%CF%85%CF%81%CE%B1.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Δίθυρα.jpg" alt="Artistic depiction of Bivalvia" id="alassa-bivalvia-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(6)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample36/thumbs_dir/U36_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample36/thumbs_dir/U36_1_thumb.jpg" alt="Pre-preparation">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample36/thumbs_dir/U36_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample36/thumbs_dir/U36_2_thumb.jpg" alt="Radiating lines are visible">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample36/thumbs_dir/U36_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample36/thumbs_dir/U36_3_thumb.jpg" alt="Radiating lines are visible">
+                                                </picture>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-6" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample36/U36_1.jpg" id="gallery-img-12">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample36/thumbs_dir/U36_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample36/thumbs_dir/U36_1_thumb.jpg" alt="Pre-preparation">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample36/U36_2.jpg" id="gallery-img-13">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample36/thumbs_dir/U36_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample36/thumbs_dir/U36_2_thumb.jpg" alt="Radiating lines are visible">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample36/U36_3.jpg" id="gallery-img-14">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample36/thumbs_dir/U36_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample36/thumbs_dir/U36_3_thumb.jpg" alt="Radiating lines are visible">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                <section id="alassa-chordata-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/chordata/chordata.html" style="text-decoration: none;">
+                            <h1 id="chordata"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/chordata/chordata.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%A7%CE%BF%CF%81%CE%B4%CF%89%CF%84%CE%AC.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Χορδωτά.jpg" alt="Artistic depiction of Chordata" id="alassa-chordata-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(7)">
+                                    
+                                    <picture class="image-single">
+                                        <source srcset="../images/cy_collection/sample8/thumbs_dir/U8_1_thumb.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/cy_collection/sample8/thumbs_dir/U8_1_thumb.jpg" alt="Spine and (?)fins">
+                                    </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-7" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample8/U8_1.jpg" id="gallery-img-15">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample8/thumbs_dir/U8_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample8/thumbs_dir/U8_1_thumb.jpg" alt="Spine and (?)fins">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(8)">
+                                    
+                                    <picture class="image-single">
+                                        <source srcset="../images/cy_collection/sample9/thumbs_dir/U9_1_thumb.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/cy_collection/sample9/thumbs_dir/U9_1_thumb.jpg" alt="Scale and (?)plant remains">
+                                    </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-8" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample9/U9_1.jpg" id="gallery-img-16">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample9/thumbs_dir/U9_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample9/thumbs_dir/U9_1_thumb.jpg" alt="Scale and (?)plant remains">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(9)">
+                                    
+                                    <picture class="image-single">
+                                        <source srcset="../images/cy_collection/sample10/thumbs_dir/U10_1_thumb.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/cy_collection/sample10/thumbs_dir/U10_1_thumb.jpg" alt="Spine and (?)head">
+                                    </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-9" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample10/U10_1.jpg" id="gallery-img-17">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample10/thumbs_dir/U10_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample10/thumbs_dir/U10_1_thumb.jpg" alt="Spine and (?)head">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(10)">
+                                    
+                                    <picture class="image-single">
+                                        <source srcset="../images/cy_collection/sample11/thumbs_dir/U11_1_thumb.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/cy_collection/sample11/thumbs_dir/U11_1_thumb.jpg" alt="Spine and (?)head">
+                                    </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-10" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample11/U11_1.jpg" id="gallery-img-18">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample11/thumbs_dir/U11_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample11/thumbs_dir/U11_1_thumb.jpg" alt="Spine and (?)head">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(11)">
+                                    
+                                    <picture class="image-single">
+                                        <source srcset="../images/cy_collection/sample12/thumbs_dir/U12_1_thumb.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/cy_collection/sample12/thumbs_dir/U12_1_thumb.jpg" alt="Spine and (?)part of body">
+                                    </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-11" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample12/U12_1.jpg" id="gallery-img-19">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample12/thumbs_dir/U12_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample12/thumbs_dir/U12_1_thumb.jpg" alt="Spine and (?)part of body">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(12)">
+                                    
+                                    <div class="image-two">
+                                        <picture class="image-main">
+                                            <source srcset="../images/cy_collection/sample25/thumbs_dir/U25_1_thumb.webp 1x" type="image/webp">
+                                            <img loading="lazy" src="../images/cy_collection/sample25/thumbs_dir/U25_1_thumb.jpg" alt="Scales (from a tail?)">
+                                        </picture>
                                         <div class="image-overlay">+1</div>
-                                        
                                     </div>
-                                </div>
-                            </div>
-                            
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-24" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample37/U37_1.jpg" id="gallery-img-50">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_1_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample37/U37_2.jpg" id="gallery-img-51">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_2_thumb.jpg" alt="Unclear detail with spine - perhaps a fish head">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample37/U37_3.jpg" id="gallery-img-52">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_3_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample37/U37_4.jpg" id="gallery-img-53">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_4_thumb.jpg" alt="Detail">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(25)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample38/thumbs_dir/U38_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample38/thumbs_dir/U38_1_thumb.jpg" alt="Pre-preparation">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample38/thumbs_dir/U38_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample38/thumbs_dir/U38_2_thumb.jpg" alt="Prepared. Bird(?)">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample38/thumbs_dir/U38_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample38/thumbs_dir/U38_3_thumb.jpg" alt="Damaged (by preparation)">
-                                        </picture>
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-12" style="display: none;">
                                         
+                                        
+                                        <a href="../images/cy_collection/sample25/U25_1.jpg" id="gallery-img-20">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample25/thumbs_dir/U25_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample25/thumbs_dir/U25_1_thumb.jpg" alt="Scales (from a tail?)">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample25/U25_2.jpg" id="gallery-img-21">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample25/thumbs_dir/U25_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample25/thumbs_dir/U25_2_thumb.jpg" alt="Detail">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(13)">
+                                    
+                                    <picture class="image-single">
+                                        <source srcset="../images/cy_collection/sample27/thumbs_dir/U27_1_thumb.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/cy_collection/sample27/thumbs_dir/U27_1_thumb.jpg" alt="Spine and (?)head">
+                                    </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-13" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample27/U27_1.jpg" id="gallery-img-22">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample27/thumbs_dir/U27_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample27/thumbs_dir/U27_1_thumb.jpg" alt="Spine and (?)head">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(14)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_1_thumb.jpg" alt="Scales (of a fish?), elongated shape. 7 fragments">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_2_thumb.jpg" alt="3 large fragments">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_3_thumb.jpg" alt="Large fragments. Side Α">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+6</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-14" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample28/U28_1.jpg" id="gallery-img-23">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_1_thumb.jpg" alt="Scales (of a fish?), elongated shape. 7 fragments">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample28/U28_2.jpg" id="gallery-img-24">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_2_thumb.jpg" alt="3 large fragments">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample28/U28_3.jpg" id="gallery-img-25">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_3_thumb.jpg" alt="Large fragments. Side Α">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample28/U28_4.jpg" id="gallery-img-26">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_4_thumb.jpg" alt="Large fragment. Side B">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample28/U28_5.jpg" id="gallery-img-27">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_5_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_5_thumb.jpg" alt="Small fragments">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample28/U28_6.jpg" id="gallery-img-28">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_6_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_6_thumb.jpg" alt="Small fragment A, detail">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample28/U28_7.jpg" id="gallery-img-29">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_7_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_7_thumb.jpg" alt="Small fragment B, detail">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample28/U28_8.jpg" id="gallery-img-30">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_8_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_8_thumb.jpg" alt="Small fragment C, detail">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample28/U28_9.jpg" id="gallery-img-31">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample28/thumbs_dir/U28_9_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample28/thumbs_dir/U28_9_thumb.jpg" alt="Small fragment D, detail">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(15)">
+                                    
+                                    <picture class="image-single">
+                                        <source srcset="../images/cy_collection/sample31/thumbs_dir/U31_1_thumb.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/cy_collection/sample31/thumbs_dir/U31_1_thumb.jpg" alt="Spine and (?)head">
+                                    </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-15" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample31/U31_1.jpg" id="gallery-img-32">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample31/thumbs_dir/U31_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample31/thumbs_dir/U31_1_thumb.jpg" alt="Spine and (?)head">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(16)">
+                                    
+                                    <picture class="image-single">
+                                        <source srcset="../images/cy_collection/sample33/thumbs_dir/U33_1_thumb.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/cy_collection/sample33/thumbs_dir/U33_1_thumb.jpg" alt="Scales">
+                                    </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-16" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample33/U33_1.jpg" id="gallery-img-33">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample33/thumbs_dir/U33_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample33/thumbs_dir/U33_1_thumb.jpg" alt="Scales">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(17)">
+                                    
+                                    <div class="image-two">
+                                        <picture class="image-main">
+                                            <source srcset="../images/cy_collection/sample35/thumbs_dir/U35_1_thumb.webp 1x" type="image/webp">
+                                            <img loading="lazy" src="../images/cy_collection/sample35/thumbs_dir/U35_1_thumb.jpg" alt="Scale">
+                                        </picture>
                                         <div class="image-overlay">+1</div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-17" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample35/U35_1.jpg" id="gallery-img-34">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample35/thumbs_dir/U35_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample35/thumbs_dir/U35_1_thumb.jpg" alt="Scale">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample35/U35_2.jpg" id="gallery-img-35">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample35/thumbs_dir/U35_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample35/thumbs_dir/U35_2_thumb.jpg" alt="Detail">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-25" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample38/U38_1.jpg" id="gallery-img-54">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample38/thumbs_dir/U38_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample38/thumbs_dir/U38_1_thumb.jpg" alt="Pre-preparation">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample38/U38_2.jpg" id="gallery-img-55">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample38/thumbs_dir/U38_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample38/thumbs_dir/U38_2_thumb.jpg" alt="Prepared. Bird(?)">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample38/U38_3.jpg" id="gallery-img-56">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample38/thumbs_dir/U38_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample38/thumbs_dir/U38_3_thumb.jpg" alt="Damaged (by preparation)">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample38/U38_4.jpg" id="gallery-img-57">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample38/thumbs_dir/U38_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample38/thumbs_dir/U38_4_thumb.jpg" alt="Damaged (by washing)">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(26)">
                             
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample39/thumbs_dir/U39_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample39/thumbs_dir/U39_1_thumb.jpg" alt="Scale + negative impression">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample39/thumbs_dir/U39_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample39/thumbs_dir/U39_2_thumb.jpg" alt="Scale">
-                                        </picture>
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(18)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_2_thumb.jpg" alt="Unclear detail with spine - perhaps a fish head">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+1</div>
+                                                
+                                            </div>
+                                        </div>
                                     </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample39/thumbs_dir/U39_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample39/thumbs_dir/U39_3_thumb.jpg" alt="Negative impression">
-                                        </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-18" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample37/U37_1.jpg" id="gallery-img-36">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample37/U37_2.jpg" id="gallery-img-37">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_2_thumb.jpg" alt="Unclear detail with spine - perhaps a fish head">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample37/U37_3.jpg" id="gallery-img-38">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample37/U37_4.jpg" id="gallery-img-39">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_4_thumb.jpg" alt="Detail">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-26" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample39/U39_1.jpg" id="gallery-img-58">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample39/thumbs_dir/U39_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample39/thumbs_dir/U39_1_thumb.jpg" alt="Scale + negative impression">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample39/U39_2.jpg" id="gallery-img-59">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample39/thumbs_dir/U39_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample39/thumbs_dir/U39_2_thumb.jpg" alt="Scale">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample39/U39_3.jpg" id="gallery-img-60">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample39/thumbs_dir/U39_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample39/thumbs_dir/U39_3_thumb.jpg" alt="Negative impression">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(27)">
                             
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample40/thumbs_dir/U40_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample40/thumbs_dir/U40_1_thumb.jpg" alt="Various plant(?) impressions">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample40/thumbs_dir/U40_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample40/thumbs_dir/U40_2_thumb.jpg" alt="Detail">
-                                        </picture>
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(19)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample39/thumbs_dir/U39_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample39/thumbs_dir/U39_1_thumb.jpg" alt="Scale + negative impression">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample39/thumbs_dir/U39_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample39/thumbs_dir/U39_2_thumb.jpg" alt="Scale">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample39/thumbs_dir/U39_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample39/thumbs_dir/U39_3_thumb.jpg" alt="Negative impression">
+                                                </picture>
+                                                
+                                            </div>
+                                        </div>
                                     </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample40/thumbs_dir/U40_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample40/thumbs_dir/U40_3_thumb.jpg" alt="Detail">
-                                        </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-19" style="display: none;">
                                         
-                                        <div class="image-overlay">+1</div>
+                                        
+                                        <a href="../images/cy_collection/sample39/U39_1.jpg" id="gallery-img-40">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample39/thumbs_dir/U39_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample39/thumbs_dir/U39_1_thumb.jpg" alt="Scale + negative impression">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample39/U39_2.jpg" id="gallery-img-41">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample39/thumbs_dir/U39_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample39/thumbs_dir/U39_2_thumb.jpg" alt="Scale">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample39/U39_3.jpg" id="gallery-img-42">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample39/thumbs_dir/U39_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample39/thumbs_dir/U39_3_thumb.jpg" alt="Negative impression">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-27" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample40/U40_1.jpg" id="gallery-img-61">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample40/thumbs_dir/U40_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample40/thumbs_dir/U40_1_thumb.jpg" alt="Various plant(?) impressions">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample40/U40_2.jpg" id="gallery-img-62">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample40/thumbs_dir/U40_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample40/thumbs_dir/U40_2_thumb.jpg" alt="Detail">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample40/U40_3.jpg" id="gallery-img-63">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample40/thumbs_dir/U40_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample40/thumbs_dir/U40_3_thumb.jpg" alt="Detail">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample40/U40_4.jpg" id="gallery-img-64">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample40/thumbs_dir/U40_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample40/thumbs_dir/U40_4_thumb.jpg" alt="Perhaps Posidonia oceanica">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(28)">
                             
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample41/thumbs_dir/U41_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample41/thumbs_dir/U41_1_thumb.jpg" alt="Fish tail">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-28" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample41/U41_1.jpg" id="gallery-img-65">
-                                    <picture>
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(20)">
+                                    
+                                    <picture class="image-single">
                                         <source srcset="../images/cy_collection/sample41/thumbs_dir/U41_1_thumb.webp 1x" type="image/webp">
                                         <img loading="lazy" src="../images/cy_collection/sample41/thumbs_dir/U41_1_thumb.jpg" alt="Fish tail">
                                     </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(29)">
-                            
-                            <div class="image-two">
-                                <picture class="image-main">
-                                    <source srcset="../images/cy_collection/sample42/thumbs_dir/U42_1_thumb.webp 1x" type="image/webp">
-                                    <img loading="lazy" src="../images/cy_collection/sample42/thumbs_dir/U42_1_thumb.jpg" alt="">
-                                </picture>
-                                <div class="image-overlay">+1</div>
-                            </div>
-                            
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-29" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample42/U42_1.jpg" id="gallery-img-66">
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-20" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample41/U41_1.jpg" id="gallery-img-43">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample41/thumbs_dir/U41_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample41/thumbs_dir/U41_1_thumb.jpg" alt="Fish tail">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(21)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_1_thumb.jpg" alt="View A">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_2_thumb.jpg" alt="View A - detail. Fish(?)">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_3_thumb.jpg" alt="View B">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+1</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-21" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample44/U44_1.jpg" id="gallery-img-44">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_1_thumb.jpg" alt="View A">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample44/U44_2.jpg" id="gallery-img-45">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_2_thumb.jpg" alt="View A - detail. Fish(?)">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample44/U44_3.jpg" id="gallery-img-46">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_3_thumb.jpg" alt="View B">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample44/U44_4.jpg" id="gallery-img-47">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_4_thumb.jpg" alt="View B - detail. Posidonia oceanica(?)">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                <section id="alassa-heterobrissus_montesi-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/echinodermata/echinoidea/euechinoidea/spatangoida/heterobrissus/heterobrissus_montesi/heterobrissus_montesi.html" style="text-decoration: none;">
+                            <h1 id="heterobrissus_montesi"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/echinodermata/echinoidea/euechinoidea/spatangoida/heterobrissus/heterobrissus_montesi/heterobrissus_montesi.html">
                                     <picture>
-                                        <source srcset="../images/cy_collection/sample42/thumbs_dir/U42_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample42/thumbs_dir/U42_1_thumb.jpg" alt="">
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%95%CF%84%CE%B5%CF%81%CE%BF%CE%B2%CF%81%CE%AF%CF%83%CF%83%CE%BF%CF%82%20%CE%BF%20%CE%BC%CE%BF%CE%BD%CF%84%CE%AD%CF%83%CE%B9%CE%BF%CF%82.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Ετεροβρίσσος ο μοντέσιος.jpg" alt="Artistic depiction of Heterobrissus montesi" id="alassa-heterobrissus_montesi-εικόνα">
                                     </picture>
                                 </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample42/U42_2.jpg" id="gallery-img-67">
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(22)">
+                                    
+                                    <div class="image-two">
+                                        <picture class="image-main">
+                                            <source srcset="../images/cy_collection/sample22/thumbs_dir/U22_1_thumb.webp 1x" type="image/webp">
+                                            <img loading="lazy" src="../images/cy_collection/sample22/thumbs_dir/U22_1_thumb.jpg" alt="In-situ, in a riverbed. Very eroded">
+                                        </picture>
+                                        <div class="image-overlay">+1</div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-22" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample22/U22_1.jpg" id="gallery-img-48">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample22/thumbs_dir/U22_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample22/thumbs_dir/U22_1_thumb.jpg" alt="In-situ, in a riverbed. Very eroded">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample22/U22_2.jpg" id="gallery-img-49">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample22/thumbs_dir/U22_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample22/thumbs_dir/U22_2_thumb.jpg" alt="~8cm">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(23)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample23/thumbs_dir/U23_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample23/thumbs_dir/U23_1_thumb.jpg" alt="In-situ, inside the matrix">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample23/thumbs_dir/U23_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample23/thumbs_dir/U23_2_thumb.jpg" alt="After digging up">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample23/thumbs_dir/U23_3_done_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample23/thumbs_dir/U23_3_done_thumb.jpg" alt="The sample has been removed from the rock">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+2</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-23" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample23/U23_1.jpg" id="gallery-img-50">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample23/thumbs_dir/U23_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample23/thumbs_dir/U23_1_thumb.jpg" alt="In-situ, inside the matrix">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample23/U23_2.jpg" id="gallery-img-51">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample23/thumbs_dir/U23_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample23/thumbs_dir/U23_2_thumb.jpg" alt="After digging up">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample23/U23_3_done.jpg" id="gallery-img-52">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample23/thumbs_dir/U23_3_done_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample23/thumbs_dir/U23_3_done_thumb.jpg" alt="The sample has been removed from the rock">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample23/U23_4.jpg" id="gallery-img-53">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample23/thumbs_dir/U23_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample23/thumbs_dir/U23_4_thumb.jpg" alt="Apical view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample23/U23_5.jpg" id="gallery-img-54">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample23/thumbs_dir/U23_5_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample23/thumbs_dir/U23_5_thumb.jpg" alt="Oral view">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                <section id="alassa-ostreida-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/mollusca/bivalvia/autobranchia/ostreida/ostreida.html" style="text-decoration: none;">
+                            <h1 id="ostreida"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/mollusca/bivalvia/autobranchia/ostreida/ostreida.html">
                                     <picture>
-                                        <source srcset="../images/cy_collection/sample42/thumbs_dir/U42_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample42/thumbs_dir/U42_2_thumb.jpg" alt="">
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%9F%CF%83%CF%84%CF%81%CE%B5%CE%AF%CE%B4%CE%B9%CE%B1.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Οστρείδια.jpg" alt="Artistic depiction of Ostreida" id="alassa-ostreida-εικόνα">
                                     </picture>
                                 </a>
-                                
                             </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(30)">
                             
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample43/thumbs_dir/U43_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample43/thumbs_dir/U43_1_thumb.jpg" alt="">
-                            </picture>
                             
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(24)">
+                                    
+                                    <div class="image-two">
+                                        <picture class="image-main">
+                                            <source srcset="../images/cy_collection/sample46/thumbs_dir/U46_1_thumb.webp 1x" type="image/webp">
+                                            <img loading="lazy" src="../images/cy_collection/sample46/thumbs_dir/U46_1_thumb.jpg" alt="">
+                                        </picture>
+                                        <div class="image-overlay">+1</div>
+                                    </div>
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-30" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample43/U43_1.jpg" id="gallery-img-68">
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-24" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample46/U46_1.jpg" id="gallery-img-55">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample46/thumbs_dir/U46_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample46/thumbs_dir/U46_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample46/U46_2.jpg" id="gallery-img-56">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample46/thumbs_dir/U46_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample46/thumbs_dir/U46_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                <section id="alassa-plantae-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/plantae/plantae.html" style="text-decoration: none;">
+                            <h1 id="plantae"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/plantae/plantae.html">
                                     <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%A6%CF%85%CF%84%CE%AC.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Φυτά.jpg" alt="Artistic depiction of Plantae" id="alassa-plantae-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(25)">
+                                    
+                                    <picture class="image-single">
+                                        <source srcset="../images/cy_collection/sample5/thumbs_dir/U5_1_thumb.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/cy_collection/sample5/thumbs_dir/U5_1_thumb.jpg" alt="Leaf">
+                                    </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-25" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample5/U5_1.jpg" id="gallery-img-57">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample5/thumbs_dir/U5_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample5/thumbs_dir/U5_1_thumb.jpg" alt="Leaf">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(26)">
+                                    
+                                    <picture class="image-single">
+                                        <source srcset="../images/cy_collection/sample9/thumbs_dir/U9_1_thumb.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/cy_collection/sample9/thumbs_dir/U9_1_thumb.jpg" alt="Scale and (?)plant remains">
+                                    </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-26" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample9/U9_1.jpg" id="gallery-img-58">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample9/thumbs_dir/U9_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample9/thumbs_dir/U9_1_thumb.jpg" alt="Scale and (?)plant remains">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(27)">
+                                    
+                                    <picture class="image-single">
+                                        <source srcset="../images/cy_collection/sample29/thumbs_dir/U29_1_thumb.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/cy_collection/sample29/thumbs_dir/U29_1_thumb.jpg" alt="Plant(?) - perhaps Posidonia oceanica?">
+                                    </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-27" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample29/U29_1.jpg" id="gallery-img-59">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample29/thumbs_dir/U29_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample29/thumbs_dir/U29_1_thumb.jpg" alt="Plant(?) - perhaps Posidonia oceanica?">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(28)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample40/thumbs_dir/U40_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample40/thumbs_dir/U40_1_thumb.jpg" alt="Various plant(?) impressions">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample40/thumbs_dir/U40_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample40/thumbs_dir/U40_2_thumb.jpg" alt="Detail">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample40/thumbs_dir/U40_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample40/thumbs_dir/U40_3_thumb.jpg" alt="Detail">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+1</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-28" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample40/U40_1.jpg" id="gallery-img-60">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample40/thumbs_dir/U40_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample40/thumbs_dir/U40_1_thumb.jpg" alt="Various plant(?) impressions">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample40/U40_2.jpg" id="gallery-img-61">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample40/thumbs_dir/U40_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample40/thumbs_dir/U40_2_thumb.jpg" alt="Detail">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample40/U40_3.jpg" id="gallery-img-62">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample40/thumbs_dir/U40_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample40/thumbs_dir/U40_3_thumb.jpg" alt="Detail">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample40/U40_4.jpg" id="gallery-img-63">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample40/thumbs_dir/U40_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample40/thumbs_dir/U40_4_thumb.jpg" alt="Perhaps Posidonia oceanica">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(29)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_1_thumb.jpg" alt="View A">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_2_thumb.jpg" alt="View A - detail. Fish(?)">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_3_thumb.jpg" alt="View B">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+1</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-29" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample44/U44_1.jpg" id="gallery-img-64">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_1_thumb.jpg" alt="View A">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample44/U44_2.jpg" id="gallery-img-65">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_2_thumb.jpg" alt="View A - detail. Fish(?)">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample44/U44_3.jpg" id="gallery-img-66">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_3_thumb.jpg" alt="View B">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample44/U44_4.jpg" id="gallery-img-67">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_4_thumb.jpg" alt="View B - detail. Posidonia oceanica(?)">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                <section id="alassa-unclassified-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../unclassified.html" style="text-decoration: none;">
+                            <h1 id="unclassified"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../unclassified.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%91%CE%BA%CE%B1%CF%84%CE%B7%CE%B3%CE%BF%CF%81%CE%B9%CE%BF%CF%80%CE%BF%CE%AF%CE%B7%CF%84%CE%B1.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Ακατηγοριοποίητα.jpg" alt="Artistic depiction of Unclassified" id="alassa-unclassified-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(30)">
+                                    
+                                    <picture class="image-single">
+                                        <source srcset="../images/cy_collection/sample2/thumbs_dir/U2_1_thumb.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/cy_collection/sample2/thumbs_dir/U2_1_thumb.jpg" alt="Unknown">
+                                    </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-30" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample2/U2_1.jpg" id="gallery-img-68">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample2/thumbs_dir/U2_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample2/thumbs_dir/U2_1_thumb.jpg" alt="Unknown">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(31)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_1_thumb.jpg" alt="Conical impressions.">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_2_thumb.jpg" alt="Conical impressions.">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_3_thumb.jpg" alt="Conical impressions.">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+4</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-31" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample32/U32_1.jpg" id="gallery-img-69">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_1_thumb.jpg" alt="Conical impressions.">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample32/U32_2.jpg" id="gallery-img-70">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_2_thumb.jpg" alt="Conical impressions.">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample32/U32_3.jpg" id="gallery-img-71">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_3_thumb.jpg" alt="Conical impressions.">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample32/U32_4.jpg" id="gallery-img-72">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_4_thumb.jpg" alt="Conical impressions.">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample32/U32_5.jpg" id="gallery-img-73">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_5_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_5_thumb.jpg" alt="Conical impressions.">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample32/U32_6.jpg" id="gallery-img-74">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_6_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_6_thumb.jpg" alt="Conical impressions.">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample32/U32_7.jpg" id="gallery-img-75">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample32/thumbs_dir/U32_7_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample32/thumbs_dir/U32_7_thumb.jpg" alt="Conical impressions.">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(32)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_2_thumb.jpg" alt="Unclear detail with spine - perhaps a fish head">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+1</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-32" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample37/U37_1.jpg" id="gallery-img-76">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample37/U37_2.jpg" id="gallery-img-77">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_2_thumb.jpg" alt="Unclear detail with spine - perhaps a fish head">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample37/U37_3.jpg" id="gallery-img-78">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample37/U37_4.jpg" id="gallery-img-79">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample37/thumbs_dir/U37_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample37/thumbs_dir/U37_4_thumb.jpg" alt="Detail">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(33)">
+                                    
+                                    <div class="image-two">
+                                        <picture class="image-main">
+                                            <source srcset="../images/cy_collection/sample42/thumbs_dir/U42_1_thumb.webp 1x" type="image/webp">
+                                            <img loading="lazy" src="../images/cy_collection/sample42/thumbs_dir/U42_1_thumb.jpg" alt="">
+                                        </picture>
+                                        <div class="image-overlay">+1</div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-33" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample42/U42_1.jpg" id="gallery-img-80">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample42/thumbs_dir/U42_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample42/thumbs_dir/U42_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample42/U42_2.jpg" id="gallery-img-81">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample42/thumbs_dir/U42_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample42/thumbs_dir/U42_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(34)">
+                                    
+                                    <picture class="image-single">
                                         <source srcset="../images/cy_collection/sample43/thumbs_dir/U43_1_thumb.webp 1x" type="image/webp">
                                         <img loading="lazy" src="../images/cy_collection/sample43/thumbs_dir/U43_1_thumb.jpg" alt="">
                                     </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(31)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_1_thumb.jpg" alt="View A">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_2_thumb.jpg" alt="View A - detail. Fish(?)">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_3_thumb.jpg" alt="View B">
-                                        </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-34" style="display: none;">
                                         
-                                        <div class="image-overlay">+1</div>
+                                        
+                                        <a href="../images/cy_collection/sample43/U43_1.jpg" id="gallery-img-82">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample43/thumbs_dir/U43_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample43/thumbs_dir/U43_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-31" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample44/U44_1.jpg" id="gallery-img-69">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_1_thumb.jpg" alt="View A">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample44/U44_2.jpg" id="gallery-img-70">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_2_thumb.jpg" alt="View A - detail. Fish(?)">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample44/U44_3.jpg" id="gallery-img-71">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_3_thumb.jpg" alt="View B">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample44/U44_4.jpg" id="gallery-img-72">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample44/thumbs_dir/U44_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample44/thumbs_dir/U44_4_thumb.jpg" alt="View B - detail. Posidonia oceanica(?)">
-                                    </picture>
-                                </a>
-                                
-                            </div>
                         </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(32)">
-                            
-                            <div class="image-two">
-                                <picture class="image-main">
-                                    <source srcset="../images/cy_collection/sample46/thumbs_dir/U46_1_thumb.webp 1x" type="image/webp">
-                                    <img loading="lazy" src="../images/cy_collection/sample46/thumbs_dir/U46_1_thumb.jpg" alt="">
-                                </picture>
-                                <div class="image-overlay">+1</div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-32" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample46/U46_1.jpg" id="gallery-img-73">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample46/thumbs_dir/U46_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample46/thumbs_dir/U46_1_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample46/U46_2.jpg" id="gallery-img-74">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample46/thumbs_dir/U46_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample46/thumbs_dir/U46_2_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
                     </div>
-                </div>
-            </section>
-        </main>
+                </section>
+                <section id="alassa-venus-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/mollusca/bivalvia/autobranchia/veneridae/venus/venus.html" style="text-decoration: none;">
+                            <h1 id="venus"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/mollusca/bivalvia/autobranchia/veneridae/venus/venus.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%92%CE%AD%CE%BD%CE%BF%CF%82.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Βένος.jpg" alt="Artistic depiction of Venus" id="alassa-venus-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(35)">
+                                    
+                                    <picture class="image-single">
+                                        <source srcset="../images/cy_collection/sample30/thumbs_dir/U30_1_thumb.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/cy_collection/sample30/thumbs_dir/U30_1_thumb.jpg" alt="3-4 shells. One likely of the genus Venus">
+                                    </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-35" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample30/U30_1.jpg" id="gallery-img-83">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample30/thumbs_dir/U30_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample30/thumbs_dir/U30_1_thumb.jpg" alt="3-4 shells. One likely of the genus Venus">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                </main>
     </div>
 
     <footer>
@@ -1372,8 +1756,8 @@
         id="language-script"
         src="../scripts/language.js"
         dict="/localities/alassa.json"
-        keys="τίτλος,alassa,alassa-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,alassa-formation,alassa-depositional_environment,alassa-fossil_types,alassa-paleoecology_highlights,middle,miocene,serravallian,mya,longshore-drift-description"
-        galleryLength="74"
+        keys="τίτλος,alassa,alassa-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,alassa-formation,alassa-depositional_environment,alassa-fossil_types,alassa-paleoecology_highlights,middle,miocene,serravallian,unclassified,plantae,actinopterygii,chordata,heterobrissus_montesi,venus,bivalvia,aves,ostreida,mya"
+        galleryLength="83"
     ></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lightgallery/2.7.2/lightgallery.min.js" integrity="sha384-MjUNxSaHL/6eoaiJXs3NcsYt5PMcFos3RjoGKaBj8wqEu0lYAn0HISvhdiF8fjec" crossorigin="anonymous"></script>

--- a/localities/alnif_ktaoua.html
+++ b/localities/alnif_ktaoua.html
@@ -57,82 +57,95 @@
                 </div>
             </section>
 
-            <section id="alnif_ktaoua-gallery">
-                <div class="tax-subcontainer">
-                    <div class="gallery" id="gallery-">
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(1)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
+            <section id="alnif_ktaoua-orthoceratoidea-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/mollusca/cephalopoda/orthoceratoidea/orthoceratoidea.html" style="text-decoration: none;">
+                            <h1 id="orthoceratoidea"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/mollusca/cephalopoda/orthoceratoidea/orthoceratoidea.html">
                                     <picture>
-                                        <source srcset="../images/ma_collection/sample12/thumbs_dir/MA_12_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample12/thumbs_dir/MA_12_1_thumb.jpg" alt="">
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%9F%CF%81%CE%B8%CE%BF%CE%BA%CE%B5%CF%81%CE%B1%CF%84%CE%BF%CE%B5%CE%B9%CE%B4%CE%AE.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Ορθοκερατοειδή.jpg" alt="Artistic depiction of Orthoceratoidea" id="alnif_ktaoua-orthoceratoidea-εικόνα">
                                     </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample12/thumbs_dir/MA_12_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample12/thumbs_dir/MA_12_2_thumb.jpg" alt="">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample12/thumbs_dir/MA_12_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample12/thumbs_dir/MA_12_3_thumb.jpg" alt="">
-                                        </picture>
-                                        
-                                        <div class="image-overlay">+1</div>
-                                        
-                                    </div>
-                                </div>
+                                </a>
                             </div>
                             
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(1)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample12/thumbs_dir/MA_12_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample12/thumbs_dir/MA_12_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample12/thumbs_dir/MA_12_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample12/thumbs_dir/MA_12_2_thumb.jpg" alt="">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample12/thumbs_dir/MA_12_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample12/thumbs_dir/MA_12_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+1</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-1" style="display: none;">
-                                
-                                
-                                <a href="../images/ma_collection/sample12/MA_12_1.jpg" id="gallery-img-1">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample12/thumbs_dir/MA_12_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample12/thumbs_dir/MA_12_1_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample12/MA_12_2.jpg" id="gallery-img-2">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample12/thumbs_dir/MA_12_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample12/thumbs_dir/MA_12_2_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample12/MA_12_3.jpg" id="gallery-img-3">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample12/thumbs_dir/MA_12_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample12/thumbs_dir/MA_12_3_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample12/MA_12_4.jpg" id="gallery-img-4">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample12/thumbs_dir/MA_12_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample12/thumbs_dir/MA_12_4_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-1" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample12/MA_12_1.jpg" id="gallery-img-1">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample12/thumbs_dir/MA_12_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample12/thumbs_dir/MA_12_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample12/MA_12_2.jpg" id="gallery-img-2">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample12/thumbs_dir/MA_12_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample12/thumbs_dir/MA_12_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample12/MA_12_3.jpg" id="gallery-img-3">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample12/thumbs_dir/MA_12_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample12/thumbs_dir/MA_12_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample12/MA_12_4.jpg" id="gallery-img-4">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample12/thumbs_dir/MA_12_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample12/thumbs_dir/MA_12_4_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
                             </div>
+                            
                         </div>
-                    
                     </div>
-                </div>
-            </section>
-        </main>
+                </section>
+                </main>
     </div>
 
     <footer>
@@ -147,7 +160,7 @@
         id="language-script"
         src="../scripts/language.js"
         dict="/localities/alnif_ktaoua.json"
-        keys="τίτλος,alnif_ktaoua,alnif_ktaoua-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,alnif_ktaoua-formation,alnif_ktaoua-depositional_environment,alnif_ktaoua-fossil_types,alnif_ktaoua-paleoecology_highlights,late,ordovician,katian,mya,longshore-drift-description"
+        keys="τίτλος,alnif_ktaoua,alnif_ktaoua-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,alnif_ktaoua-formation,alnif_ktaoua-depositional_environment,alnif_ktaoua-fossil_types,alnif_ktaoua-paleoecology_highlights,late,ordovician,katian,orthoceratoidea,mya"
         galleryLength="4"
     ></script>
 

--- a/localities/chapel-st-leonards.html
+++ b/localities/chapel-st-leonards.html
@@ -65,232 +65,285 @@
                 </div>
             </section>
 
-            <section id="chapel-st-leonards-gallery">
-                <div class="tax-subcontainer">
-                    <div class="gallery" id="gallery-">
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(1)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
+            <section id="chapel-st-leonards-anthozoa-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/cnidaria/anthozoa/anthozoa.html" style="text-decoration: none;">
+                            <h1 id="anthozoa"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/cnidaria/anthozoa/anthozoa.html">
                                     <picture>
-                                        <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_1_thumb.jpg" alt="Measurement 14-15cm">
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%91%CE%BD%CE%B8%CF%8C%CE%B6%CF%89%CE%B1.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Ανθόζωα.jpg" alt="Artistic depiction of Anthozoa" id="chapel-st-leonards-anthozoa-εικόνα">
                                     </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_2_thumb.jpg" alt="">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_3_thumb.jpg" alt="">
-                                        </picture>
-                                        
-                                        <div class="image-overlay">+3</div>
-                                        
-                                    </div>
-                                </div>
+                                </a>
                             </div>
                             
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(1)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_1_thumb.jpg" alt="Measurement 14-15cm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_2_thumb.jpg" alt="">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+3</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-1" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample21/U_21_1.jpg" id="gallery-img-1">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_1_thumb.jpg" alt="Measurement 14-15cm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample21/U_21_2.jpg" id="gallery-img-2">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_2_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample21/U_21_3.jpg" id="gallery-img-3">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_3_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample21/U_21_4.jpg" id="gallery-img-4">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_4_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample21/U_21_5.jpg" id="gallery-img-5">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_5_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_5_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample21/U_21_6.jpg" id="gallery-img-6">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_6_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_6_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(2)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample22/thumbs_dir/U_22_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample22/thumbs_dir/U_22_1_thumb.jpg" alt="Measurement 7-8cm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample22/thumbs_dir/U_22_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample22/thumbs_dir/U_22_2_thumb.jpg" alt="">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample22/thumbs_dir/U_22_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample22/thumbs_dir/U_22_3_thumb.jpg" alt="">
-                                        </picture>
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-1" style="display: none;">
                                         
-                                        <div class="image-overlay">+2</div>
+                                        
+                                        <a href="../images/uk_collection/sample21/U_21_1.jpg" id="gallery-img-1">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_1_thumb.jpg" alt="Measurement 14-15cm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample21/U_21_2.jpg" id="gallery-img-2">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample21/U_21_3.jpg" id="gallery-img-3">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample21/U_21_4.jpg" id="gallery-img-4">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_4_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample21/U_21_5.jpg" id="gallery-img-5">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_5_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_5_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample21/U_21_6.jpg" id="gallery-img-6">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample21/thumbs_dir/U_21_6_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample21/thumbs_dir/U_21_6_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-2" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample22/U_22_1.jpg" id="gallery-img-7">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample22/thumbs_dir/U_22_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample22/thumbs_dir/U_22_1_thumb.jpg" alt="Measurement 7-8cm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample22/U_22_2.jpg" id="gallery-img-8">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample22/thumbs_dir/U_22_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample22/thumbs_dir/U_22_2_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample22/U_22_3.jpg" id="gallery-img-9">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample22/thumbs_dir/U_22_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample22/thumbs_dir/U_22_3_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample22/U_22_4.jpg" id="gallery-img-10">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample22/thumbs_dir/U_22_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample22/thumbs_dir/U_22_4_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample22/U_22_5.jpg" id="gallery-img-11">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample22/thumbs_dir/U_22_5_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample22/thumbs_dir/U_22_5_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                            </div>
                         </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(3)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample23/thumbs_dir/U_23_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample23/thumbs_dir/U_23_1_thumb.jpg" alt="Measurement 7-8cm">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample23/thumbs_dir/U_23_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample23/thumbs_dir/U_23_2_thumb.jpg" alt="">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/uk_collection/sample23/thumbs_dir/U_23_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/uk_collection/sample23/thumbs_dir/U_23_3_thumb.jpg" alt="">
-                                        </picture>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-3" style="display: none;">
-                                
-                                
-                                <a href="../images/uk_collection/sample23/U_23_1.jpg" id="gallery-img-12">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample23/thumbs_dir/U_23_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample23/thumbs_dir/U_23_1_thumb.jpg" alt="Measurement 7-8cm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample23/U_23_2.jpg" id="gallery-img-13">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample23/thumbs_dir/U_23_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample23/thumbs_dir/U_23_2_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/uk_collection/sample23/U_23_3.jpg" id="gallery-img-14">
-                                    <picture>
-                                        <source srcset="../images/uk_collection/sample23/thumbs_dir/U_23_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/uk_collection/sample23/thumbs_dir/U_23_3_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
                     </div>
-                </div>
-            </section>
-        </main>
+                </section>
+                <section id="chapel-st-leonards-gryphaea-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/mollusca/bivalvia/autobranchia/ostreida/gryphaea/gryphaea.html" style="text-decoration: none;">
+                            <h1 id="gryphaea"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/mollusca/bivalvia/autobranchia/ostreida/gryphaea/gryphaea.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%93%CF%81%CF%85%CF%86%CE%B1%CE%AF%CE%B1.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Γρυφαία.jpg" alt="Artistic depiction of Gryphaea" id="chapel-st-leonards-gryphaea-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(2)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample22/thumbs_dir/U_22_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample22/thumbs_dir/U_22_1_thumb.jpg" alt="Measurement 7-8cm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample22/thumbs_dir/U_22_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample22/thumbs_dir/U_22_2_thumb.jpg" alt="">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample22/thumbs_dir/U_22_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample22/thumbs_dir/U_22_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+2</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-2" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample22/U_22_1.jpg" id="gallery-img-7">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample22/thumbs_dir/U_22_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample22/thumbs_dir/U_22_1_thumb.jpg" alt="Measurement 7-8cm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample22/U_22_2.jpg" id="gallery-img-8">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample22/thumbs_dir/U_22_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample22/thumbs_dir/U_22_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample22/U_22_3.jpg" id="gallery-img-9">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample22/thumbs_dir/U_22_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample22/thumbs_dir/U_22_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample22/U_22_4.jpg" id="gallery-img-10">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample22/thumbs_dir/U_22_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample22/thumbs_dir/U_22_4_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample22/U_22_5.jpg" id="gallery-img-11">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample22/thumbs_dir/U_22_5_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample22/thumbs_dir/U_22_5_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                <section id="chapel-st-leonards-orthoceratoidea-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/mollusca/cephalopoda/orthoceratoidea/orthoceratoidea.html" style="text-decoration: none;">
+                            <h1 id="orthoceratoidea"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/mollusca/cephalopoda/orthoceratoidea/orthoceratoidea.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%9F%CF%81%CE%B8%CE%BF%CE%BA%CE%B5%CF%81%CE%B1%CF%84%CE%BF%CE%B5%CE%B9%CE%B4%CE%AE.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Ορθοκερατοειδή.jpg" alt="Artistic depiction of Orthoceratoidea" id="chapel-st-leonards-orthoceratoidea-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(3)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample23/thumbs_dir/U_23_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample23/thumbs_dir/U_23_1_thumb.jpg" alt="Measurement 7-8cm">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample23/thumbs_dir/U_23_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample23/thumbs_dir/U_23_2_thumb.jpg" alt="">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/uk_collection/sample23/thumbs_dir/U_23_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/uk_collection/sample23/thumbs_dir/U_23_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-3" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample23/U_23_1.jpg" id="gallery-img-12">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample23/thumbs_dir/U_23_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample23/thumbs_dir/U_23_1_thumb.jpg" alt="Measurement 7-8cm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample23/U_23_2.jpg" id="gallery-img-13">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample23/thumbs_dir/U_23_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample23/thumbs_dir/U_23_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/uk_collection/sample23/U_23_3.jpg" id="gallery-img-14">
+                                            <picture>
+                                                <source srcset="../images/uk_collection/sample23/thumbs_dir/U_23_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/uk_collection/sample23/thumbs_dir/U_23_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                </main>
     </div>
 
     <footer>
@@ -305,7 +358,7 @@
         id="language-script"
         src="../scripts/language.js"
         dict="/localities/chapel-st-leonards.json"
-        keys="τίτλος,chapel-st-leonards,chapel-st-leonards-περιγραφή-1,chapel-st-leonards-περιγραφή-2,chapel-st-leonards-περιγραφή-3,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,chapel-st-leonards-formation,chapel-st-leonards-depositional_environment,chapel-st-leonards-fossil_types,chapel-st-leonards-paleoecology_highlights,άγνωστο,mya,longshore-drift-description"
+        keys="τίτλος,chapel-st-leonards,chapel-st-leonards-περιγραφή-1,chapel-st-leonards-περιγραφή-2,chapel-st-leonards-περιγραφή-3,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,chapel-st-leonards-formation,chapel-st-leonards-depositional_environment,chapel-st-leonards-fossil_types,chapel-st-leonards-paleoecology_highlights,άγνωστο,anthozoa,gryphaea,orthoceratoidea,longshore-drift-description,mya"
         galleryLength="14"
     ></script>
 

--- a/localities/kem-kem.html
+++ b/localities/kem-kem.html
@@ -57,326 +57,345 @@
                 </div>
             </section>
 
-            <section id="kem-kem-gallery">
-                <div class="tax-subcontainer">
-                    <div class="gallery" id="gallery-">
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(1)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
+            <section id="kem-kem-spinosaurus-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/chordata/osteichthyes/sarcopterygii/sauropsida/dinosauria/theropoda/spinosauridae/spinosaurus/spinosaurus.html" style="text-decoration: none;">
+                            <h1 id="spinosaurus"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/chordata/osteichthyes/sarcopterygii/sauropsida/dinosauria/theropoda/spinosauridae/spinosaurus/spinosaurus.html">
                                     <picture>
-                                        <source srcset="../images/ma_collection/sample1/thumbs_dir/MA_1_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample1/thumbs_dir/MA_1_1_thumb.jpg" alt="">
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%A3%CF%80%CE%B9%CE%BD%CF%8C%CF%83%CE%B1%CF%85%CF%81%CE%BF%CF%82.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Σπινόσαυρος.jpg" alt="Artistic depiction of Spinosaurus" id="kem-kem-spinosaurus-εικόνα">
                                     </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample1/thumbs_dir/MA_1_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample1/thumbs_dir/MA_1_2_thumb.jpg" alt="">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample1/thumbs_dir/MA_1_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample1/thumbs_dir/MA_1_3_thumb.jpg" alt="">
-                                        </picture>
-                                        
-                                        <div class="image-overlay">+2</div>
-                                        
-                                    </div>
-                                </div>
+                                </a>
                             </div>
                             
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(1)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample1/thumbs_dir/MA_1_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample1/thumbs_dir/MA_1_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample1/thumbs_dir/MA_1_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample1/thumbs_dir/MA_1_2_thumb.jpg" alt="">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample1/thumbs_dir/MA_1_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample1/thumbs_dir/MA_1_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+2</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-1" style="display: none;">
-                                
-                                
-                                <a href="../images/ma_collection/sample1/MA_1_1.jpg" id="gallery-img-1">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample1/thumbs_dir/MA_1_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample1/thumbs_dir/MA_1_1_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample1/MA_1_2.jpg" id="gallery-img-2">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample1/thumbs_dir/MA_1_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample1/thumbs_dir/MA_1_2_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample1/MA_1_3.jpg" id="gallery-img-3">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample1/thumbs_dir/MA_1_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample1/thumbs_dir/MA_1_3_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample1/MA_1_4.jpg" id="gallery-img-4">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample1/thumbs_dir/MA_1_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample1/thumbs_dir/MA_1_4_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample1/MA_1_5.jpg" id="gallery-img-5">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample1/thumbs_dir/MA_1_5_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample1/thumbs_dir/MA_1_5_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(2)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample2/thumbs_dir/MA_2_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample2/thumbs_dir/MA_2_1_thumb.jpg" alt="">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample2/thumbs_dir/MA_2_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample2/thumbs_dir/MA_2_2_thumb.jpg" alt="">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample2/thumbs_dir/MA_2_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample2/thumbs_dir/MA_2_3_thumb.jpg" alt="">
-                                        </picture>
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-1" style="display: none;">
                                         
-                                        <div class="image-overlay">+2</div>
+                                        
+                                        <a href="../images/ma_collection/sample1/MA_1_1.jpg" id="gallery-img-1">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample1/thumbs_dir/MA_1_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample1/thumbs_dir/MA_1_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample1/MA_1_2.jpg" id="gallery-img-2">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample1/thumbs_dir/MA_1_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample1/thumbs_dir/MA_1_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample1/MA_1_3.jpg" id="gallery-img-3">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample1/thumbs_dir/MA_1_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample1/thumbs_dir/MA_1_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample1/MA_1_4.jpg" id="gallery-img-4">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample1/thumbs_dir/MA_1_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample1/thumbs_dir/MA_1_4_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample1/MA_1_5.jpg" id="gallery-img-5">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample1/thumbs_dir/MA_1_5_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample1/thumbs_dir/MA_1_5_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(2)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample2/thumbs_dir/MA_2_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample2/thumbs_dir/MA_2_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample2/thumbs_dir/MA_2_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample2/thumbs_dir/MA_2_2_thumb.jpg" alt="">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample2/thumbs_dir/MA_2_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample2/thumbs_dir/MA_2_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+2</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-2" style="display: none;">
-                                
-                                
-                                <a href="../images/ma_collection/sample2/MA_2_1.jpg" id="gallery-img-6">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample2/thumbs_dir/MA_2_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample2/thumbs_dir/MA_2_1_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample2/MA_2_2.jpg" id="gallery-img-7">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample2/thumbs_dir/MA_2_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample2/thumbs_dir/MA_2_2_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample2/MA_2_3.jpg" id="gallery-img-8">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample2/thumbs_dir/MA_2_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample2/thumbs_dir/MA_2_3_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample2/MA_2_4.jpg" id="gallery-img-9">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample2/thumbs_dir/MA_2_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample2/thumbs_dir/MA_2_4_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample2/MA_2_5.jpg" id="gallery-img-10">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample2/thumbs_dir/MA_2_5_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample2/thumbs_dir/MA_2_5_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(3)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_1_thumb.jpg" alt="">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_2_thumb.jpg" alt="">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_3_thumb.jpg" alt="">
-                                        </picture>
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-2" style="display: none;">
                                         
-                                        <div class="image-overlay">+3</div>
+                                        
+                                        <a href="../images/ma_collection/sample2/MA_2_1.jpg" id="gallery-img-6">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample2/thumbs_dir/MA_2_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample2/thumbs_dir/MA_2_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample2/MA_2_2.jpg" id="gallery-img-7">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample2/thumbs_dir/MA_2_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample2/thumbs_dir/MA_2_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample2/MA_2_3.jpg" id="gallery-img-8">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample2/thumbs_dir/MA_2_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample2/thumbs_dir/MA_2_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample2/MA_2_4.jpg" id="gallery-img-9">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample2/thumbs_dir/MA_2_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample2/thumbs_dir/MA_2_4_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample2/MA_2_5.jpg" id="gallery-img-10">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample2/thumbs_dir/MA_2_5_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample2/thumbs_dir/MA_2_5_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(3)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_2_thumb.jpg" alt="">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+3</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-3" style="display: none;">
-                                
-                                
-                                <a href="../images/ma_collection/sample3/MA_3_1.jpg" id="gallery-img-11">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_1_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample3/MA_3_2.jpg" id="gallery-img-12">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_2_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample3/MA_3_3.jpg" id="gallery-img-13">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_3_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample3/MA_3_4.jpg" id="gallery-img-14">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_4_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample3/MA_3_5.jpg" id="gallery-img-15">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_5_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_5_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample3/MA_3_6.jpg" id="gallery-img-16">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_6_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_6_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(4)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample4/thumbs_dir/MA_4_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample4/thumbs_dir/MA_4_1_thumb.jpg" alt="">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample4/thumbs_dir/MA_4_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample4/thumbs_dir/MA_4_2_thumb.jpg" alt="">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample4/thumbs_dir/MA_4_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample4/thumbs_dir/MA_4_3_thumb.jpg" alt="">
-                                        </picture>
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-3" style="display: none;">
                                         
-                                        <div class="image-overlay">+2</div>
+                                        
+                                        <a href="../images/ma_collection/sample3/MA_3_1.jpg" id="gallery-img-11">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample3/MA_3_2.jpg" id="gallery-img-12">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample3/MA_3_3.jpg" id="gallery-img-13">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample3/MA_3_4.jpg" id="gallery-img-14">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_4_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample3/MA_3_5.jpg" id="gallery-img-15">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_5_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_5_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample3/MA_3_6.jpg" id="gallery-img-16">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample3/thumbs_dir/MA_3_6_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample3/thumbs_dir/MA_3_6_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(4)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample4/thumbs_dir/MA_4_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample4/thumbs_dir/MA_4_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample4/thumbs_dir/MA_4_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample4/thumbs_dir/MA_4_2_thumb.jpg" alt="">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample4/thumbs_dir/MA_4_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample4/thumbs_dir/MA_4_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+2</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-4" style="display: none;">
-                                
-                                
-                                <a href="../images/ma_collection/sample4/MA_4_1.jpg" id="gallery-img-17">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample4/thumbs_dir/MA_4_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample4/thumbs_dir/MA_4_1_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample4/MA_4_2.jpg" id="gallery-img-18">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample4/thumbs_dir/MA_4_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample4/thumbs_dir/MA_4_2_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample4/MA_4_3.jpg" id="gallery-img-19">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample4/thumbs_dir/MA_4_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample4/thumbs_dir/MA_4_3_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample4/MA_4_4.jpg" id="gallery-img-20">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample4/thumbs_dir/MA_4_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample4/thumbs_dir/MA_4_4_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample4/MA_4_5.jpg" id="gallery-img-21">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample4/thumbs_dir/MA_4_5_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample4/thumbs_dir/MA_4_5_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-4" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample4/MA_4_1.jpg" id="gallery-img-17">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample4/thumbs_dir/MA_4_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample4/thumbs_dir/MA_4_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample4/MA_4_2.jpg" id="gallery-img-18">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample4/thumbs_dir/MA_4_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample4/thumbs_dir/MA_4_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample4/MA_4_3.jpg" id="gallery-img-19">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample4/thumbs_dir/MA_4_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample4/thumbs_dir/MA_4_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample4/MA_4_4.jpg" id="gallery-img-20">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample4/thumbs_dir/MA_4_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample4/thumbs_dir/MA_4_4_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample4/MA_4_5.jpg" id="gallery-img-21">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample4/thumbs_dir/MA_4_5_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample4/thumbs_dir/MA_4_5_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
                             </div>
+                            
                         </div>
-                    
                     </div>
-                </div>
-            </section>
-        </main>
+                </section>
+                </main>
     </div>
 
     <footer>
@@ -391,7 +410,7 @@
         id="language-script"
         src="../scripts/language.js"
         dict="/localities/kem-kem.json"
-        keys="τίτλος,kem-kem,kem-kem-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,kem-kem-formation,kem-kem-depositional_environment,kem-kem-fossil_types,kem-kem-paleoecology_highlights,late,cretaceous,cenomanian,mya,longshore-drift-description"
+        keys="τίτλος,kem-kem,kem-kem-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,kem-kem-formation,kem-kem-depositional_environment,kem-kem-fossil_types,kem-kem-paleoecology_highlights,late,cretaceous,cenomanian,spinosaurus,mya"
         galleryLength="21"
     ></script>
 

--- a/localities/lefkothea.html
+++ b/localities/lefkothea.html
@@ -57,83 +57,118 @@
                 </div>
             </section>
 
-            <section id="lefkothea-gallery">
-                <div class="tax-subcontainer">
-                    <div class="gallery" id="gallery-">
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(1)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample1/thumbs_dir/U1_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample1/thumbs_dir/U1_1_thumb.jpg" alt="Unknown">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-1" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample1/U1_1.jpg" id="gallery-img-1">
+            <section id="lefkothea-chordata-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/chordata/chordata.html" style="text-decoration: none;">
+                            <h1 id="chordata"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/chordata/chordata.html">
                                     <picture>
-                                        <source srcset="../images/cy_collection/sample1/thumbs_dir/U1_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample1/thumbs_dir/U1_1_thumb.jpg" alt="Unknown">
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%A7%CE%BF%CF%81%CE%B4%CF%89%CF%84%CE%AC.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Χορδωτά.jpg" alt="Artistic depiction of Chordata" id="lefkothea-chordata-εικόνα">
                                     </picture>
                                 </a>
-                                
                             </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(2)">
                             
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample3/thumbs_dir/U3_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample3/thumbs_dir/U3_1_thumb.jpg" alt="Leaf">
-                            </picture>
                             
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-2" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample3/U3_1.jpg" id="gallery-img-2">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample3/thumbs_dir/U3_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample3/thumbs_dir/U3_1_thumb.jpg" alt="Leaf">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(3)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample4/thumbs_dir/U4_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample4/thumbs_dir/U4_1_thumb.jpg" alt="Scale">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-3" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample4/U4_1.jpg" id="gallery-img-3">
-                                    <picture>
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(1)">
+                                    
+                                    <picture class="image-single">
                                         <source srcset="../images/cy_collection/sample4/thumbs_dir/U4_1_thumb.webp 1x" type="image/webp">
                                         <img loading="lazy" src="../images/cy_collection/sample4/thumbs_dir/U4_1_thumb.jpg" alt="Scale">
                                     </picture>
-                                </a>
-                                
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-1" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample4/U4_1.jpg" id="gallery-img-1">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample4/thumbs_dir/U4_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample4/thumbs_dir/U4_1_thumb.jpg" alt="Scale">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
                             </div>
+                            
                         </div>
-                    
                     </div>
-                </div>
-            </section>
-        </main>
+                </section>
+                <section id="lefkothea-plantae-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/plantae/plantae.html" style="text-decoration: none;">
+                            <h1 id="plantae"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/plantae/plantae.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%A6%CF%85%CF%84%CE%AC.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Φυτά.jpg" alt="Artistic depiction of Plantae" id="lefkothea-plantae-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(2)">
+                                    
+                                    <picture class="image-single">
+                                        <source srcset="../images/cy_collection/sample1/thumbs_dir/U1_1_thumb.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/cy_collection/sample1/thumbs_dir/U1_1_thumb.jpg" alt="Unknown">
+                                    </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-2" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample1/U1_1.jpg" id="gallery-img-2">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample1/thumbs_dir/U1_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample1/thumbs_dir/U1_1_thumb.jpg" alt="Unknown">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(3)">
+                                    
+                                    <picture class="image-single">
+                                        <source srcset="../images/cy_collection/sample3/thumbs_dir/U3_1_thumb.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/cy_collection/sample3/thumbs_dir/U3_1_thumb.jpg" alt="Leaf">
+                                    </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-3" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample3/U3_1.jpg" id="gallery-img-3">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample3/thumbs_dir/U3_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample3/thumbs_dir/U3_1_thumb.jpg" alt="Leaf">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                </main>
     </div>
 
     <footer>
@@ -148,7 +183,7 @@
         id="language-script"
         src="../scripts/language.js"
         dict="/localities/lefkothea.json"
-        keys="τίτλος,lefkothea,lefkothea-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,lefkothea-formation,lefkothea-depositional_environment,lefkothea-fossil_types,lefkothea-paleoecology_highlights,middle,miocene,mya,longshore-drift-description"
+        keys="τίτλος,lefkothea,lefkothea-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,lefkothea-formation,lefkothea-depositional_environment,lefkothea-fossil_types,lefkothea-paleoecology_highlights,middle,miocene,plantae,chordata,mya"
         galleryLength="3"
     ></script>
 

--- a/localities/mari.html
+++ b/localities/mari.html
@@ -57,221 +57,296 @@
                 </div>
             </section>
 
-            <section id="mari-gallery">
-                <div class="tax-subcontainer">
-                    <div class="gallery" id="gallery-">
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(1)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
+            <section id="mari-argonautidae-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/mollusca/cephalopoda/orthoceratoidea/coleoidea/argonautidae/argonautidae.html" style="text-decoration: none;">
+                            <h1 id="argonautidae"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/mollusca/cephalopoda/orthoceratoidea/coleoidea/argonautidae/argonautidae.html">
                                     <picture>
-                                        <source srcset="../images/cy_collection/sample17/thumbs_dir/U17_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample17/thumbs_dir/U17_1_thumb.jpg" alt="(?)Burrowing hole">
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%91%CF%81%CE%B3%CE%BF%CE%BD%CE%B1%CF%85%CF%84%CE%AF%CE%B4%CE%B5%CF%82.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Αργοναυτίδες.jpg" alt="Artistic depiction of Argonautidae" id="mari-argonautidae-εικόνα">
                                     </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample17/thumbs_dir/U17_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample17/thumbs_dir/U17_2_thumb.jpg" alt="(?)Burrowing hole">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample17/thumbs_dir/U17_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample17/thumbs_dir/U17_3_thumb.jpg" alt="(?)Burrowing hole">
-                                        </picture>
-                                        
-                                    </div>
-                                </div>
+                                </a>
                             </div>
                             
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-1" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample17/U17_1.jpg" id="gallery-img-1">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample17/thumbs_dir/U17_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample17/thumbs_dir/U17_1_thumb.jpg" alt="(?)Burrowing hole">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample17/U17_2.jpg" id="gallery-img-2">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample17/thumbs_dir/U17_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample17/thumbs_dir/U17_2_thumb.jpg" alt="(?)Burrowing hole">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample17/U17_3.jpg" id="gallery-img-3">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample17/thumbs_dir/U17_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample17/thumbs_dir/U17_3_thumb.jpg" alt="(?)Burrowing hole">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(2)">
                             
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample18/thumbs_dir/U18_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample18/thumbs_dir/U18_1_thumb.jpg" alt="(?)Burrowing hole">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample18/thumbs_dir/U18_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample18/thumbs_dir/U18_2_thumb.jpg" alt="(?)Burrowing hole">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample18/thumbs_dir/U18_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample18/thumbs_dir/U18_3_thumb.jpg" alt="(?)Burrowing hole">
-                                        </picture>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-2" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample18/U18_1.jpg" id="gallery-img-4">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample18/thumbs_dir/U18_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample18/thumbs_dir/U18_1_thumb.jpg" alt="(?)Burrowing hole">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample18/U18_2.jpg" id="gallery-img-5">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample18/thumbs_dir/U18_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample18/thumbs_dir/U18_2_thumb.jpg" alt="(?)Burrowing hole">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample18/U18_3.jpg" id="gallery-img-6">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample18/thumbs_dir/U18_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample18/thumbs_dir/U18_3_thumb.jpg" alt="(?)Burrowing hole">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(3)">
-                            
-                            <div class="image-two">
-                                <picture class="image-main">
-                                    <source srcset="../images/cy_collection/sample19/thumbs_dir/U19_1_thumb.webp 1x" type="image/webp">
-                                    <img loading="lazy" src="../images/cy_collection/sample19/thumbs_dir/U19_1_thumb.jpg" alt="Broken, ~2.5cm length">
-                                </picture>
-                                <div class="image-overlay">+1</div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-3" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample19/U19_1.jpg" id="gallery-img-7">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample19/thumbs_dir/U19_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample19/thumbs_dir/U19_1_thumb.jpg" alt="Broken, ~2.5cm length">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample19/U19_2.jpg" id="gallery-img-8">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample19/thumbs_dir/U19_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample19/thumbs_dir/U19_2_thumb.jpg" alt="Broken, ~2.5cm length">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(4)">
-                            
-                            <div class="image-two">
-                                <picture class="image-main">
-                                    <source srcset="../images/cy_collection/sample20/thumbs_dir/U20_1_thumb.webp 1x" type="image/webp">
-                                    <img loading="lazy" src="../images/cy_collection/sample20/thumbs_dir/U20_1_thumb.jpg" alt="Broken, ~2cm length">
-                                </picture>
-                                <div class="image-overlay">+1</div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-4" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample20/U20_1.jpg" id="gallery-img-9">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample20/thumbs_dir/U20_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample20/thumbs_dir/U20_1_thumb.jpg" alt="Broken, ~2cm length">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample20/U20_2.jpg" id="gallery-img-10">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample20/thumbs_dir/U20_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample20/thumbs_dir/U20_2_thumb.jpg" alt="Broken, ~2cm length">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(5)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample21/thumbs_dir/U21_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample21/thumbs_dir/U21_1_thumb.jpg" alt="Egg case - Unknown Argonautid - ~8cm">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-5" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample21/U21_1.jpg" id="gallery-img-11">
-                                    <picture>
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(1)">
+                                    
+                                    <picture class="image-single">
                                         <source srcset="../images/cy_collection/sample21/thumbs_dir/U21_1_thumb.webp 1x" type="image/webp">
                                         <img loading="lazy" src="../images/cy_collection/sample21/thumbs_dir/U21_1_thumb.jpg" alt="Egg case - Unknown Argonautid - ~8cm">
                                     </picture>
-                                </a>
-                                
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-1" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample21/U21_1.jpg" id="gallery-img-1">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample21/thumbs_dir/U21_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample21/thumbs_dir/U21_1_thumb.jpg" alt="Egg case - Unknown Argonautid - ~8cm">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
                             </div>
+                            
                         </div>
-                    
                     </div>
-                </div>
-            </section>
-        </main>
+                </section>
+                <section id="mari-gastropoda-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/mollusca/gastropoda/gastropoda.html" style="text-decoration: none;">
+                            <h1 id="gastropoda"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/mollusca/gastropoda/gastropoda.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%93%CE%B1%CF%83%CF%84%CF%81%CF%8C%CF%80%CE%BF%CE%B4%CE%B1.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Γαστρόποδα.jpg" alt="Artistic depiction of Gastropoda" id="mari-gastropoda-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(2)">
+                                    
+                                    <div class="image-two">
+                                        <picture class="image-main">
+                                            <source srcset="../images/cy_collection/sample20/thumbs_dir/U20_1_thumb.webp 1x" type="image/webp">
+                                            <img loading="lazy" src="../images/cy_collection/sample20/thumbs_dir/U20_1_thumb.jpg" alt="Broken, ~2cm length">
+                                        </picture>
+                                        <div class="image-overlay">+1</div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-2" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample20/U20_1.jpg" id="gallery-img-2">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample20/thumbs_dir/U20_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample20/thumbs_dir/U20_1_thumb.jpg" alt="Broken, ~2cm length">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample20/U20_2.jpg" id="gallery-img-3">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample20/thumbs_dir/U20_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample20/thumbs_dir/U20_2_thumb.jpg" alt="Broken, ~2cm length">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                <section id="mari-turritellidae-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/mollusca/gastropoda/caenogastropoda/turritellidae/turritellidae.html" style="text-decoration: none;">
+                            <h1 id="turritellidae"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/mollusca/gastropoda/caenogastropoda/turritellidae/turritellidae.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%A4%CE%BF%CF%85%CF%81%CF%81%CE%B9%CF%84%CE%B5%CE%BB%CE%BB%CE%AF%CE%B4%CE%B5%CF%82.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Τουρριτελλίδες.jpg" alt="Artistic depiction of Turritellidae" id="mari-turritellidae-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(3)">
+                                    
+                                    <div class="image-two">
+                                        <picture class="image-main">
+                                            <source srcset="../images/cy_collection/sample19/thumbs_dir/U19_1_thumb.webp 1x" type="image/webp">
+                                            <img loading="lazy" src="../images/cy_collection/sample19/thumbs_dir/U19_1_thumb.jpg" alt="Broken, ~2.5cm length">
+                                        </picture>
+                                        <div class="image-overlay">+1</div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-3" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample19/U19_1.jpg" id="gallery-img-4">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample19/thumbs_dir/U19_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample19/thumbs_dir/U19_1_thumb.jpg" alt="Broken, ~2.5cm length">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample19/U19_2.jpg" id="gallery-img-5">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample19/thumbs_dir/U19_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample19/thumbs_dir/U19_2_thumb.jpg" alt="Broken, ~2.5cm length">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                <section id="mari-unclassified-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../unclassified.html" style="text-decoration: none;">
+                            <h1 id="unclassified"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../unclassified.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%91%CE%BA%CE%B1%CF%84%CE%B7%CE%B3%CE%BF%CF%81%CE%B9%CE%BF%CF%80%CE%BF%CE%AF%CE%B7%CF%84%CE%B1.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Ακατηγοριοποίητα.jpg" alt="Artistic depiction of Unclassified" id="mari-unclassified-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(4)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample17/thumbs_dir/U17_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample17/thumbs_dir/U17_1_thumb.jpg" alt="(?)Burrowing hole">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample17/thumbs_dir/U17_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample17/thumbs_dir/U17_2_thumb.jpg" alt="(?)Burrowing hole">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample17/thumbs_dir/U17_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample17/thumbs_dir/U17_3_thumb.jpg" alt="(?)Burrowing hole">
+                                                </picture>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-4" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample17/U17_1.jpg" id="gallery-img-6">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample17/thumbs_dir/U17_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample17/thumbs_dir/U17_1_thumb.jpg" alt="(?)Burrowing hole">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample17/U17_2.jpg" id="gallery-img-7">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample17/thumbs_dir/U17_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample17/thumbs_dir/U17_2_thumb.jpg" alt="(?)Burrowing hole">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample17/U17_3.jpg" id="gallery-img-8">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample17/thumbs_dir/U17_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample17/thumbs_dir/U17_3_thumb.jpg" alt="(?)Burrowing hole">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(5)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample18/thumbs_dir/U18_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample18/thumbs_dir/U18_1_thumb.jpg" alt="(?)Burrowing hole">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample18/thumbs_dir/U18_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample18/thumbs_dir/U18_2_thumb.jpg" alt="(?)Burrowing hole">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample18/thumbs_dir/U18_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample18/thumbs_dir/U18_3_thumb.jpg" alt="(?)Burrowing hole">
+                                                </picture>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-5" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample18/U18_1.jpg" id="gallery-img-9">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample18/thumbs_dir/U18_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample18/thumbs_dir/U18_1_thumb.jpg" alt="(?)Burrowing hole">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample18/U18_2.jpg" id="gallery-img-10">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample18/thumbs_dir/U18_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample18/thumbs_dir/U18_2_thumb.jpg" alt="(?)Burrowing hole">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample18/U18_3.jpg" id="gallery-img-11">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample18/thumbs_dir/U18_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample18/thumbs_dir/U18_3_thumb.jpg" alt="(?)Burrowing hole">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                </main>
     </div>
 
     <footer>
@@ -286,7 +361,7 @@
         id="language-script"
         src="../scripts/language.js"
         dict="/localities/mari.json"
-        keys="τίτλος,mari,mari-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,mari-formation,mari-depositional_environment,mari-fossil_types,mari-paleoecology_highlights,pliocene,mya,longshore-drift-description"
+        keys="τίτλος,mari,mari-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,mari-formation,mari-depositional_environment,mari-fossil_types,mari-paleoecology_highlights,pliocene,unclassified,turritellidae,gastropoda,argonautidae,mya"
         galleryLength="11"
     ></script>
 

--- a/localities/mimarighen.html
+++ b/localities/mimarighen.html
@@ -57,476 +57,643 @@
                 </div>
             </section>
 
-            <section id="mimarighen-gallery">
-                <div class="tax-subcontainer">
-                    <div class="gallery" id="gallery-">
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(1)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
+            <section id="mimarighen-bivalvia-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/mollusca/bivalvia/bivalvia.html" style="text-decoration: none;">
+                            <h1 id="bivalvia"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/mollusca/bivalvia/bivalvia.html">
                                     <picture>
-                                        <source srcset="../images/ma_collection/sample5/thumbs_dir/MA_5_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample5/thumbs_dir/MA_5_1_thumb.jpg" alt="">
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%94%CE%AF%CE%B8%CF%85%CF%81%CE%B1.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Δίθυρα.jpg" alt="Artistic depiction of Bivalvia" id="mimarighen-bivalvia-εικόνα">
                                     </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample5/thumbs_dir/MA_5_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample5/thumbs_dir/MA_5_2_thumb.jpg" alt="">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample5/thumbs_dir/MA_5_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample5/thumbs_dir/MA_5_3_thumb.jpg" alt="">
-                                        </picture>
-                                        
-                                        <div class="image-overlay">+2</div>
-                                        
-                                    </div>
-                                </div>
+                                </a>
                             </div>
                             
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(1)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample7/thumbs_dir/MA_7_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample7/thumbs_dir/MA_7_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample7/thumbs_dir/MA_7_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample7/thumbs_dir/MA_7_2_thumb.jpg" alt="">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample7/thumbs_dir/MA_7_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample7/thumbs_dir/MA_7_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-1" style="display: none;">
-                                
-                                
-                                <a href="../images/ma_collection/sample5/MA_5_1.jpg" id="gallery-img-1">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample5/thumbs_dir/MA_5_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample5/thumbs_dir/MA_5_1_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample5/MA_5_2.jpg" id="gallery-img-2">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample5/thumbs_dir/MA_5_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample5/thumbs_dir/MA_5_2_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample5/MA_5_3.jpg" id="gallery-img-3">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample5/thumbs_dir/MA_5_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample5/thumbs_dir/MA_5_3_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample5/MA_5_4.jpg" id="gallery-img-4">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample5/thumbs_dir/MA_5_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample5/thumbs_dir/MA_5_4_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample5/MA_5_5.jpg" id="gallery-img-5">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample5/thumbs_dir/MA_5_5_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample5/thumbs_dir/MA_5_5_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-1" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample7/MA_7_1.jpg" id="gallery-img-1">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample7/thumbs_dir/MA_7_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample7/thumbs_dir/MA_7_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample7/MA_7_2.jpg" id="gallery-img-2">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample7/thumbs_dir/MA_7_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample7/thumbs_dir/MA_7_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample7/MA_7_3.jpg" id="gallery-img-3">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample7/thumbs_dir/MA_7_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample7/thumbs_dir/MA_7_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
                             </div>
+                            
                         </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(2)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample6/thumbs_dir/MA_6_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample6/thumbs_dir/MA_6_1_thumb.jpg" alt="">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample6/thumbs_dir/MA_6_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample6/thumbs_dir/MA_6_2_thumb.jpg" alt="">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample6/thumbs_dir/MA_6_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample6/thumbs_dir/MA_6_3_thumb.jpg" alt="">
-                                        </picture>
-                                        
-                                        <div class="image-overlay">+2</div>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-2" style="display: none;">
-                                
-                                
-                                <a href="../images/ma_collection/sample6/MA_6_1.jpg" id="gallery-img-6">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample6/thumbs_dir/MA_6_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample6/thumbs_dir/MA_6_1_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample6/MA_6_2.jpg" id="gallery-img-7">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample6/thumbs_dir/MA_6_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample6/thumbs_dir/MA_6_2_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample6/MA_6_3.jpg" id="gallery-img-8">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample6/thumbs_dir/MA_6_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample6/thumbs_dir/MA_6_3_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample6/MA_6_4.jpg" id="gallery-img-9">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample6/thumbs_dir/MA_6_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample6/thumbs_dir/MA_6_4_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample6/MA_6_5.jpg" id="gallery-img-10">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample6/thumbs_dir/MA_6_5_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample6/thumbs_dir/MA_6_5_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(3)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample7/thumbs_dir/MA_7_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample7/thumbs_dir/MA_7_1_thumb.jpg" alt="">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample7/thumbs_dir/MA_7_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample7/thumbs_dir/MA_7_2_thumb.jpg" alt="">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample7/thumbs_dir/MA_7_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample7/thumbs_dir/MA_7_3_thumb.jpg" alt="">
-                                        </picture>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-3" style="display: none;">
-                                
-                                
-                                <a href="../images/ma_collection/sample7/MA_7_1.jpg" id="gallery-img-11">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample7/thumbs_dir/MA_7_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample7/thumbs_dir/MA_7_1_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample7/MA_7_2.jpg" id="gallery-img-12">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample7/thumbs_dir/MA_7_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample7/thumbs_dir/MA_7_2_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample7/MA_7_3.jpg" id="gallery-img-13">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample7/thumbs_dir/MA_7_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample7/thumbs_dir/MA_7_3_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(4)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_1_thumb.jpg" alt="">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_2_thumb.jpg" alt="">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_3_thumb.jpg" alt="">
-                                        </picture>
-                                        
-                                        <div class="image-overlay">+1</div>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-4" style="display: none;">
-                                
-                                
-                                <a href="../images/ma_collection/sample8/MA_8_1.jpg" id="gallery-img-14">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_1_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample8/MA_8_2.jpg" id="gallery-img-15">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_2_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample8/MA_8_3.jpg" id="gallery-img-16">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_3_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample8/MA_8_4.jpg" id="gallery-img-17">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_4_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(5)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample9/thumbs_dir/MA_9_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample9/thumbs_dir/MA_9_1_thumb.jpg" alt="">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample9/thumbs_dir/MA_9_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample9/thumbs_dir/MA_9_2_thumb.jpg" alt="">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample9/thumbs_dir/MA_9_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample9/thumbs_dir/MA_9_3_thumb.jpg" alt="">
-                                        </picture>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-5" style="display: none;">
-                                
-                                
-                                <a href="../images/ma_collection/sample9/MA_9_1.jpg" id="gallery-img-18">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample9/thumbs_dir/MA_9_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample9/thumbs_dir/MA_9_1_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample9/MA_9_2.jpg" id="gallery-img-19">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample9/thumbs_dir/MA_9_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample9/thumbs_dir/MA_9_2_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample9/MA_9_3.jpg" id="gallery-img-20">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample9/thumbs_dir/MA_9_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample9/thumbs_dir/MA_9_3_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(6)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample10/thumbs_dir/MA_10_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample10/thumbs_dir/MA_10_1_thumb.jpg" alt="">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample10/thumbs_dir/MA_10_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample10/thumbs_dir/MA_10_2_thumb.jpg" alt="">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample10/thumbs_dir/MA_10_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample10/thumbs_dir/MA_10_3_thumb.jpg" alt="">
-                                        </picture>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-6" style="display: none;">
-                                
-                                
-                                <a href="../images/ma_collection/sample10/MA_10_1.jpg" id="gallery-img-21">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample10/thumbs_dir/MA_10_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample10/thumbs_dir/MA_10_1_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample10/MA_10_2.jpg" id="gallery-img-22">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample10/thumbs_dir/MA_10_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample10/thumbs_dir/MA_10_2_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample10/MA_10_3.jpg" id="gallery-img-23">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample10/thumbs_dir/MA_10_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample10/thumbs_dir/MA_10_3_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(7)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample11/thumbs_dir/MA_11_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample11/thumbs_dir/MA_11_1_thumb.jpg" alt="">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample11/thumbs_dir/MA_11_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample11/thumbs_dir/MA_11_2_thumb.jpg" alt="">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/ma_collection/sample11/thumbs_dir/MA_11_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/ma_collection/sample11/thumbs_dir/MA_11_3_thumb.jpg" alt="">
-                                        </picture>
-                                        
-                                        <div class="image-overlay">+1</div>
-                                        
-                                    </div>
-                                </div>
-                            </div>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-7" style="display: none;">
-                                
-                                
-                                <a href="../images/ma_collection/sample11/MA_11_1.jpg" id="gallery-img-24">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample11/thumbs_dir/MA_11_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample11/thumbs_dir/MA_11_1_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample11/MA_11_2.jpg" id="gallery-img-25">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample11/thumbs_dir/MA_11_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample11/thumbs_dir/MA_11_2_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample11/MA_11_3.jpg" id="gallery-img-26">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample11/thumbs_dir/MA_11_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample11/thumbs_dir/MA_11_3_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/ma_collection/sample11/MA_11_4.jpg" id="gallery-img-27">
-                                    <picture>
-                                        <source srcset="../images/ma_collection/sample11/thumbs_dir/MA_11_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/ma_collection/sample11/thumbs_dir/MA_11_4_thumb.jpg" alt="">
-                                    </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
                     </div>
-                </div>
-            </section>
-        </main>
+                </section>
+                <section id="mimarighen-paralejurus-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/arthropoda/trilobita/corynexochida/paralejurus/paralejurus.html" style="text-decoration: none;">
+                            <h1 id="paralejurus"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/arthropoda/trilobita/corynexochida/paralejurus/paralejurus.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%A0%CE%B1%CF%81%CE%B1%CE%BB%CE%B5%CE%B3%CE%B9%CE%BF%CF%8D%CF%81%CE%BF%CF%82.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Παραλεγιούρος.jpg" alt="Artistic depiction of Paralejurus" id="mimarighen-paralejurus-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(2)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample9/thumbs_dir/MA_9_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample9/thumbs_dir/MA_9_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample9/thumbs_dir/MA_9_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample9/thumbs_dir/MA_9_2_thumb.jpg" alt="">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample9/thumbs_dir/MA_9_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample9/thumbs_dir/MA_9_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-2" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample9/MA_9_1.jpg" id="gallery-img-4">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample9/thumbs_dir/MA_9_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample9/thumbs_dir/MA_9_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample9/MA_9_2.jpg" id="gallery-img-5">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample9/thumbs_dir/MA_9_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample9/thumbs_dir/MA_9_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample9/MA_9_3.jpg" id="gallery-img-6">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample9/thumbs_dir/MA_9_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample9/thumbs_dir/MA_9_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                <section id="mimarighen-reedops_maurulus-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/arthropoda/trilobita/phacopida/reedops/reedops_maurulus/reedops_maurulus.html" style="text-decoration: none;">
+                            <h1 id="reedops_maurulus"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/arthropoda/trilobita/phacopida/reedops/reedops_maurulus/reedops_maurulus.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%A1%CE%AE%CE%B4%CE%BF%CF%80%CE%B1%CF%82%20%CE%BF%20%CE%BC%CE%B1%CF%85%CF%81%CE%AF%CF%83%CE%BA%CE%BF%CF%82.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Ρήδοπας ο μαυρίσκος.jpg" alt="Artistic depiction of Reedops maurulus" id="mimarighen-reedops_maurulus-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(3)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample5/thumbs_dir/MA_5_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample5/thumbs_dir/MA_5_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample5/thumbs_dir/MA_5_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample5/thumbs_dir/MA_5_2_thumb.jpg" alt="">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample5/thumbs_dir/MA_5_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample5/thumbs_dir/MA_5_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+2</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-3" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample5/MA_5_1.jpg" id="gallery-img-7">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample5/thumbs_dir/MA_5_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample5/thumbs_dir/MA_5_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample5/MA_5_2.jpg" id="gallery-img-8">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample5/thumbs_dir/MA_5_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample5/thumbs_dir/MA_5_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample5/MA_5_3.jpg" id="gallery-img-9">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample5/thumbs_dir/MA_5_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample5/thumbs_dir/MA_5_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample5/MA_5_4.jpg" id="gallery-img-10">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample5/thumbs_dir/MA_5_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample5/thumbs_dir/MA_5_4_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample5/MA_5_5.jpg" id="gallery-img-11">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample5/thumbs_dir/MA_5_5_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample5/thumbs_dir/MA_5_5_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(4)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample6/thumbs_dir/MA_6_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample6/thumbs_dir/MA_6_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample6/thumbs_dir/MA_6_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample6/thumbs_dir/MA_6_2_thumb.jpg" alt="">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample6/thumbs_dir/MA_6_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample6/thumbs_dir/MA_6_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+2</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-4" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample6/MA_6_1.jpg" id="gallery-img-12">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample6/thumbs_dir/MA_6_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample6/thumbs_dir/MA_6_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample6/MA_6_2.jpg" id="gallery-img-13">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample6/thumbs_dir/MA_6_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample6/thumbs_dir/MA_6_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample6/MA_6_3.jpg" id="gallery-img-14">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample6/thumbs_dir/MA_6_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample6/thumbs_dir/MA_6_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample6/MA_6_4.jpg" id="gallery-img-15">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample6/thumbs_dir/MA_6_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample6/thumbs_dir/MA_6_4_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample6/MA_6_5.jpg" id="gallery-img-16">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample6/thumbs_dir/MA_6_5_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample6/thumbs_dir/MA_6_5_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(5)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_2_thumb.jpg" alt="">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+1</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-5" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample8/MA_8_1.jpg" id="gallery-img-17">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample8/MA_8_2.jpg" id="gallery-img-18">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample8/MA_8_3.jpg" id="gallery-img-19">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample8/MA_8_4.jpg" id="gallery-img-20">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_4_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                <section id="mimarighen-rugosa-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/cnidaria/anthozoa/rugosa/rugosa.html" style="text-decoration: none;">
+                            <h1 id="rugosa"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/cnidaria/anthozoa/rugosa/rugosa.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%A1%CF%85%CF%84%CE%B9%CE%B4%CF%89%CF%84%CE%AC.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Ρυτιδωτά.jpg" alt="Artistic depiction of Rugosa" id="mimarighen-rugosa-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(6)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample11/thumbs_dir/MA_11_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample11/thumbs_dir/MA_11_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample11/thumbs_dir/MA_11_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample11/thumbs_dir/MA_11_2_thumb.jpg" alt="">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample11/thumbs_dir/MA_11_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample11/thumbs_dir/MA_11_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+1</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-6" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample11/MA_11_1.jpg" id="gallery-img-21">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample11/thumbs_dir/MA_11_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample11/thumbs_dir/MA_11_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample11/MA_11_2.jpg" id="gallery-img-22">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample11/thumbs_dir/MA_11_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample11/thumbs_dir/MA_11_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample11/MA_11_3.jpg" id="gallery-img-23">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample11/thumbs_dir/MA_11_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample11/thumbs_dir/MA_11_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample11/MA_11_4.jpg" id="gallery-img-24">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample11/thumbs_dir/MA_11_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample11/thumbs_dir/MA_11_4_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                <section id="mimarighen-zlichovaspis-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/arthropoda/trilobita/phacopida/zlichovaspis/zlichovaspis.html" style="text-decoration: none;">
+                            <h1 id="zlichovaspis"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/arthropoda/trilobita/phacopida/zlichovaspis/zlichovaspis.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%96%CE%BB%CE%B9%CF%87%CE%BF%CE%B2%CE%AC%CF%83%CF%80%CE%B9%CF%82.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Ζλιχοβάσπις.jpg" alt="Artistic depiction of Zlichovaspis" id="mimarighen-zlichovaspis-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(7)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_2_thumb.jpg" alt="">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+1</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-7" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample8/MA_8_1.jpg" id="gallery-img-25">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample8/MA_8_2.jpg" id="gallery-img-26">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample8/MA_8_3.jpg" id="gallery-img-27">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample8/MA_8_4.jpg" id="gallery-img-28">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample8/thumbs_dir/MA_8_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample8/thumbs_dir/MA_8_4_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(8)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample10/thumbs_dir/MA_10_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample10/thumbs_dir/MA_10_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample10/thumbs_dir/MA_10_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample10/thumbs_dir/MA_10_2_thumb.jpg" alt="">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/ma_collection/sample10/thumbs_dir/MA_10_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/ma_collection/sample10/thumbs_dir/MA_10_3_thumb.jpg" alt="">
+                                                </picture>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-8" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample10/MA_10_1.jpg" id="gallery-img-29">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample10/thumbs_dir/MA_10_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample10/thumbs_dir/MA_10_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample10/MA_10_2.jpg" id="gallery-img-30">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample10/thumbs_dir/MA_10_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample10/thumbs_dir/MA_10_2_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/ma_collection/sample10/MA_10_3.jpg" id="gallery-img-31">
+                                            <picture>
+                                                <source srcset="../images/ma_collection/sample10/thumbs_dir/MA_10_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/ma_collection/sample10/thumbs_dir/MA_10_3_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                </main>
     </div>
 
     <footer>
@@ -541,8 +708,8 @@
         id="language-script"
         src="../scripts/language.js"
         dict="/localities/mimarighen.json"
-        keys="τίτλος,mimarighen,mimarighen-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,mimarighen-formation,mimarighen-depositional_environment,mimarighen-fossil_types,mimarighen-paleoecology_highlights,lower,devonian,mya,longshore-drift-description"
-        galleryLength="27"
+        keys="τίτλος,mimarighen,mimarighen-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,mimarighen-formation,mimarighen-depositional_environment,mimarighen-fossil_types,mimarighen-paleoecology_highlights,lower,devonian,reedops_maurulus,bivalvia,zlichovaspis,paralejurus,rugosa,mya"
+        galleryLength="31"
     ></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lightgallery/2.7.2/lightgallery.min.js" integrity="sha384-MjUNxSaHL/6eoaiJXs3NcsYt5PMcFos3RjoGKaBj8wqEu0lYAn0HISvhdiF8fjec" crossorigin="anonymous"></script>

--- a/localities/polemidia.html
+++ b/localities/polemidia.html
@@ -57,175 +57,248 @@
                 </div>
             </section>
 
-            <section id="polemidia-gallery">
-                <div class="tax-subcontainer">
-                    <div class="gallery" id="gallery-">
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(1)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample6/thumbs_dir/U6_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample6/thumbs_dir/U6_1_thumb.jpg" alt="Unknown autobranch, possibly a Pectinid or Lucinid">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-1" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample6/U6_1.jpg" id="gallery-img-1">
+            <section id="polemidia-autobranchia-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/mollusca/bivalvia/autobranchia/autobranchia.html" style="text-decoration: none;">
+                            <h1 id="autobranchia"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/mollusca/bivalvia/autobranchia/autobranchia.html">
                                     <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%91%CF%85%CF%84%CE%BF%CE%B2%CF%81%CE%AC%CE%B3%CF%87%CE%B9%CE%B1.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Αυτοβράγχια.jpg" alt="Artistic depiction of Autobranchia" id="polemidia-autobranchia-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(1)">
+                                    
+                                    <picture class="image-single">
                                         <source srcset="../images/cy_collection/sample6/thumbs_dir/U6_1_thumb.webp 1x" type="image/webp">
                                         <img loading="lazy" src="../images/cy_collection/sample6/thumbs_dir/U6_1_thumb.jpg" alt="Unknown autobranch, possibly a Pectinid or Lucinid">
                                     </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(2)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample14/thumbs_dir/U14_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample14/thumbs_dir/U14_1_thumb.jpg" alt="(?)Leaf">
-                            </picture>
-                            
+                                    
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-2" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample14/U14_1.jpg" id="gallery-img-2">
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-1" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample6/U6_1.jpg" id="gallery-img-1">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample6/thumbs_dir/U6_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample6/thumbs_dir/U6_1_thumb.jpg" alt="Unknown autobranch, possibly a Pectinid or Lucinid">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                <section id="polemidia-diacria_trispinosa-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/mollusca/gastropoda/heterobranchia/cavoliniidae/diacria/diacria_trispinosa/diacria_trispinosa.html" style="text-decoration: none;">
+                            <h1 id="diacria_trispinosa"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/mollusca/gastropoda/heterobranchia/cavoliniidae/diacria/diacria_trispinosa/diacria_trispinosa.html">
                                     <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%94%CE%B9%CE%B1%CE%BA%CF%81%CE%AF%CE%B1%20%CE%B7%20%CF%84%CF%81%CE%B9%CE%AC%CE%BA%CE%B1%CE%BD%CE%B8%CE%BF%CF%82.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Διακρία η τριάκανθος.jpg" alt="Artistic depiction of Diacria trispinosa" id="polemidia-diacria_trispinosa-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(2)">
+                                    
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_1_thumb.jpg" alt="Molds of at least seven individuals; the original shell material doesn't seem to be preserved">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_2_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_2_thumb.jpg" alt="Measurement 6-7mm">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_3_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_3_thumb.jpg" alt="An outline can be seen, as well as the (dorsal?) ribs.">
+                                                </picture>
+                                                
+                                                <div class="image-overlay">+4</div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-2" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample15/U15_1.jpg" id="gallery-img-2">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_1_thumb.jpg" alt="Molds of at least seven individuals; the original shell material doesn't seem to be preserved">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample15/U15_2.jpg" id="gallery-img-3">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_2_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_2_thumb.jpg" alt="Measurement 6-7mm">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample15/U15_3.jpg" id="gallery-img-4">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_3_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_3_thumb.jpg" alt="An outline can be seen, as well as the (dorsal?) ribs.">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample15/U15_4.jpg" id="gallery-img-5">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_4_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_4_thumb.jpg" alt="Ventral view. The aperture is visible as well as the three ribs that characterize the species; a wide central one and a slimmer one on either side">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample15/U15_5.jpg" id="gallery-img-6">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_5_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_5_thumb.jpg" alt="An outline can be seen, as well as faint ribs. Dorsal view">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample15/U15_6.jpg" id="gallery-img-7">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_6_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_6_thumb.jpg" alt="Dorsal view at an angle, so that the curvature at the aperture is visible">
+                                            </picture>
+                                        </a>
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample15/U15_7.jpg" id="gallery-img-8">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_7_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_7_thumb.jpg" alt="Many of the individuals are not well-preserved, with minimal details visible">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </section>
+                <section id="polemidia-plantae-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/plantae/plantae.html" style="text-decoration: none;">
+                            <h1 id="plantae"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/plantae/plantae.html">
+                                    <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%A6%CF%85%CF%84%CE%AC.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Φυτά.jpg" alt="Artistic depiction of Plantae" id="polemidia-plantae-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(3)">
+                                    
+                                    <picture class="image-single">
                                         <source srcset="../images/cy_collection/sample14/thumbs_dir/U14_1_thumb.webp 1x" type="image/webp">
                                         <img loading="lazy" src="../images/cy_collection/sample14/thumbs_dir/U14_1_thumb.jpg" alt="(?)Leaf">
                                     </picture>
-                                </a>
-                                
-                            </div>
-                        </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(3)">
-                            
-                            <div class="image-three">
-                                <div class="image-left">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_1_thumb.jpg" alt="Molds of at least seven individuals; the original shell material doesn't seem to be preserved">
-                                    </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_2_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_2_thumb.jpg" alt="Measurement 6-7mm">
-                                        </picture>
-                                    </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_3_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_3_thumb.jpg" alt="An outline can be seen, as well as the (dorsal?) ribs.">
-                                        </picture>
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-3" style="display: none;">
                                         
-                                        <div class="image-overlay">+4</div>
+                                        
+                                        <a href="../images/cy_collection/sample14/U14_1.jpg" id="gallery-img-9">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample14/thumbs_dir/U14_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample14/thumbs_dir/U14_1_thumb.jpg" alt="(?)Leaf">
+                                            </picture>
+                                        </a>
                                         
                                     </div>
                                 </div>
                             </div>
                             
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-3" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample15/U15_1.jpg" id="gallery-img-3">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_1_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_1_thumb.jpg" alt="Molds of at least seven individuals; the original shell material doesn't seem to be preserved">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample15/U15_2.jpg" id="gallery-img-4">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_2_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_2_thumb.jpg" alt="Measurement 6-7mm">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample15/U15_3.jpg" id="gallery-img-5">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_3_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_3_thumb.jpg" alt="An outline can be seen, as well as the (dorsal?) ribs.">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample15/U15_4.jpg" id="gallery-img-6">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_4_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_4_thumb.jpg" alt="Ventral view. The aperture is visible as well as the three ribs that characterize the species; a wide central one and a slimmer one on either side">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample15/U15_5.jpg" id="gallery-img-7">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_5_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_5_thumb.jpg" alt="An outline can be seen, as well as faint ribs. Dorsal view">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample15/U15_6.jpg" id="gallery-img-8">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_6_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_6_thumb.jpg" alt="Dorsal view at an angle, so that the curvature at the aperture is visible">
-                                    </picture>
-                                </a>
-                                
-                                
-                                <a href="../images/cy_collection/sample15/U15_7.jpg" id="gallery-img-9">
-                                    <picture>
-                                        <source srcset="../images/cy_collection/sample15/thumbs_dir/U15_7_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="../images/cy_collection/sample15/thumbs_dir/U15_7_thumb.jpg" alt="Many of the individuals are not well-preserved, with minimal details visible">
-                                    </picture>
-                                </a>
-                                
-                            </div>
                         </div>
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(4)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample16/thumbs_dir/U16_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample16/thumbs_dir/U16_1_thumb.jpg" alt="Unknown. Possibly a mollusc?">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-4" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample16/U16_1.jpg" id="gallery-img-10">
+                    </div>
+                </section>
+                <section id="polemidia-unclassified-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../unclassified.html" style="text-decoration: none;">
+                            <h1 id="unclassified"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../unclassified.html">
                                     <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%91%CE%BA%CE%B1%CF%84%CE%B7%CE%B3%CE%BF%CF%81%CE%B9%CE%BF%CF%80%CE%BF%CE%AF%CE%B7%CF%84%CE%B1.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Ακατηγοριοποίητα.jpg" alt="Artistic depiction of Unclassified" id="polemidia-unclassified-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(4)">
+                                    
+                                    <picture class="image-single">
                                         <source srcset="../images/cy_collection/sample16/thumbs_dir/U16_1_thumb.webp 1x" type="image/webp">
                                         <img loading="lazy" src="../images/cy_collection/sample16/thumbs_dir/U16_1_thumb.jpg" alt="Unknown. Possibly a mollusc?">
                                     </picture>
-                                </a>
-                                
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-4" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample16/U16_1.jpg" id="gallery-img-10">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample16/thumbs_dir/U16_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample16/thumbs_dir/U16_1_thumb.jpg" alt="Unknown. Possibly a mollusc?">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
                             </div>
+                            
                         </div>
-                    
                     </div>
-                </div>
-            </section>
-        </main>
+                </section>
+                </main>
     </div>
 
     <footer>
@@ -240,7 +313,7 @@
         id="language-script"
         src="../scripts/language.js"
         dict="/localities/polemidia.json"
-        keys="τίτλος,polemidia,polemidia-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,polemidia-formation,polemidia-depositional_environment,polemidia-fossil_types,polemidia-paleoecology_highlights,middle,miocene,mya,longshore-drift-description"
+        keys="τίτλος,polemidia,polemidia-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,polemidia-formation,polemidia-depositional_environment,polemidia-fossil_types,polemidia-paleoecology_highlights,middle,miocene,autobranchia,plantae,diacria_trispinosa,unclassified,mya"
         galleryLength="10"
     ></script>
 

--- a/localities/unknown-cyprus.html
+++ b/localities/unknown-cyprus.html
@@ -30,37 +30,50 @@
                 </div>
             </section>
 
-            <section id="unknown-cyprus-gallery">
-                <div class="tax-subcontainer">
-                    <div class="gallery" id="gallery-">
-                    
-                        
-                        <div class="sample-box" onclick="openGallery(1)">
-                            
-                            <picture class="image-single">
-                                <source srcset="../images/cy_collection/sample45/thumbs_dir/U45_1_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="../images/cy_collection/sample45/thumbs_dir/U45_1_thumb.jpg" alt="">
-                            </picture>
-                            
-
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-1" style="display: none;">
-                                
-                                
-                                <a href="../images/cy_collection/sample45/U45_1.jpg" id="gallery-img-1">
+            <section id="unknown-cyprus-bivalvia-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="../tree/animalia/mollusca/bivalvia/bivalvia.html" style="text-decoration: none;">
+                            <h1 id="bivalvia"></h1>
+                        </a>
+                        <div class="grid" id="gallery-">
+                            <div class="large">
+                                <a href="../tree/animalia/mollusca/bivalvia/bivalvia.html">
                                     <picture>
+                                        <source srcset="../images/thumbnails/webp_dir/%CE%94%CE%AF%CE%B8%CF%85%CF%81%CE%B1.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="../images/thumbnails/Δίθυρα.jpg" alt="Artistic depiction of Bivalvia" id="unknown-cyprus-bivalvia-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            
+                            
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery(1)">
+                                    
+                                    <picture class="image-single">
                                         <source srcset="../images/cy_collection/sample45/thumbs_dir/U45_1_thumb.webp 1x" type="image/webp">
                                         <img loading="lazy" src="../images/cy_collection/sample45/thumbs_dir/U45_1_thumb.jpg" alt="">
                                     </picture>
-                                </a>
-                                
+                                    
+
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-1" style="display: none;">
+                                        
+                                        
+                                        <a href="../images/cy_collection/sample45/U45_1.jpg" id="gallery-img-1">
+                                            <picture>
+                                                <source srcset="../images/cy_collection/sample45/thumbs_dir/U45_1_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="../images/cy_collection/sample45/thumbs_dir/U45_1_thumb.jpg" alt="">
+                                            </picture>
+                                        </a>
+                                        
+                                    </div>
+                                </div>
                             </div>
+                            
                         </div>
-                    
                     </div>
-                </div>
-            </section>
-        </main>
+                </section>
+                </main>
     </div>
 
     <footer>
@@ -75,7 +88,7 @@
         id="language-script"
         src="../scripts/language.js"
         dict="/localities/unknown-cyprus.json"
-        keys="τίτλος,unknown-cyprus,unknown-cyprus-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,unknown-cyprus-formation,unknown-cyprus-depositional_environment,unknown-cyprus-fossil_types,unknown-cyprus-paleoecology_highlights,Φανεροζωικό,mya,longshore-drift-description"
+        keys="τίτλος,unknown-cyprus,unknown-cyprus-περιγραφή-1,age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,unknown-cyprus-formation,unknown-cyprus-depositional_environment,unknown-cyprus-fossil_types,unknown-cyprus-paleoecology_highlights,Φανεροζωικό,bivalvia,mya"
         galleryLength="1"
     ></script>
 

--- a/pyscripts/site_generator/generate_site.py
+++ b/pyscripts/site_generator/generate_site.py
@@ -4,7 +4,7 @@ import jinja2
 import subprocess
 from dataclasses import dataclass, asdict
 from pathlib import Path
-from typing import TypedDict, List, Optional, Dict
+from typing import TypedDict, List, Optional, Dict, Tuple
 
 from . import SITE_ROOT, GLOBAL_DICT
 
@@ -164,24 +164,25 @@ def generate_taxonomy_tree_files(cwd: Path, current_taxon: str, taxon_dict: Taxo
             sub_cwd.mkdir(parents=True, exist_ok=True)
             generate_taxonomy_tree_files(sub_cwd, sub_taxon, sub_taxon_info)
 
+unknown_taxon_dict: TaxonDict = {
+    "name": {
+        "el": "ακατηγοριοποίητα",
+        "en": "unclassified",
+        "grc": "ἀκατηγοριοποίητα"
+    },
+    "rank": None,
+    "description": {
+        "el": ["Δείγματα που δεν μπόρεσα να ταξινομήσω σε καμία από τις κατηγορίες. Πιθανόν και να μην είναι απολιθώματα."],
+        "en": ["Samples that I could not classify into any of the categories. They may not even be fossils."],
+        "grc": ["Δείγματα ἅ οὐκ ἐδυνάμην ταξινομεῖν εἰς τινά τῶν κατηγοριῶν. Πιθανόν δε ἀπολιθώματα αὐτά μη εἶναι."]
+    },
+    "subtaxa": {},
+    "path": "unclassified.html",
+}
+
 def generate_unknown_samples_files():
     unknown_samples = [sample for sample in SAMPLES if sample.is_unknown()]
-    samples_by_locality = group_by_locality(unknown_samples)
-
-    taxon_dict: TaxonDict = {
-        "name": {
-            "el": "ακατηγοριοποίητα",
-            "en": "unclassified",
-            "grc": "ἀκατηγοριοποίητα"
-        },
-        "rank": None,
-        "description": {
-            "el": ["Δείγματα που δεν μπόρεσα να ταξινομήσω σε καμία από τις κατηγορίες. Πιθανόν και να μην είναι απολιθώματα."],
-            "en": ["Samples that I could not classify into any of the categories. They may not even be fossils."],
-            "grc": ["Δείγματα ἅ οὐκ ἐδυνάμην ταξινομεῖν εἰς τινά τῶν κατηγοριῶν. Πιθανόν δε ἀπολιθώματα αὐτά μη εἶναι."]
-        },
-        "subtaxa": {}
-    }
+    samples_by_locality = group_by_locality(unknown_samples)    
 
     html_file = SITE_ROOT / f"unclassified.html"
     template_html = JINJA_ENV.get_template("taxon.html.template")
@@ -193,15 +194,14 @@ def generate_unknown_samples_files():
         name_el="ακατηγοριοποίητα",
         subtaxa={},
         taxon_id="unclassified",
-        description_paragraphs=len(taxon_dict["description"]["el"]),
+        description_paragraphs=len(unknown_taxon_dict["description"]["el"]),
     )
     html_file.write_text(taxon_html)
 
-    # assert False, taxon_dict
     json_file = SITE_ROOT / f"unclassified.json"
     template_json = JINJA_ENV.get_template("taxon.json.template")
     taxon_json = template_json.render(
-        taxon=taxon_dict,
+        taxon=unknown_taxon_dict,
         samples_by_locality=samples_by_locality,
         to_grc_number=greek_numeral,
         globaldict=GLOBAL_DICT,
@@ -258,14 +258,40 @@ def generate_map_page():
     taxon_json = template_json.render()
     json_file.write_text(taxon_json)
 
+def group_by_taxon(samples: List[Sample]) -> Dict[str, List[Sample]]:
+    taxon_dict: Dict[str, List[Sample]] = {}
+    for sample in samples:
+        taxa = sample.lowest_taxa if isinstance(sample.lowest_taxa, list) else [sample.lowest_taxa]
+        for taxon in taxa:
+            if taxon is None:
+                taxon = "unclassified"
+            if taxon not in taxon_dict:
+                taxon_dict[taxon] = []
+            taxon_dict[taxon].append(sample)
+    return taxon_dict
+
+def flatten_taxonomy_tree(path: Path, taxonomy: Dict[str, TaxonDict]) -> List[Tuple[str, TaxonDict]]:
+    flat_taxonomy = []
+    for taxon, taxon_info in taxonomy.items():
+        taxon_info["path"] = path / taxon / f"{taxon}.html"
+        flat_taxonomy.append((taxon, taxon_info))
+        if "subtaxa" in taxon_info and taxon_info["subtaxa"]:
+            flat_taxonomy.extend(flatten_taxonomy_tree(path / taxon, taxon_info["subtaxa"]))
+    return flat_taxonomy
+
 def generate_locality_pages():
     # Clean up old locality pages
     subprocess.run(["rm", "-rf", "localities"])
     os.mkdir("localities")
     # this method generates  /localities/<loc>.html pages with a page for each locality in geochronology.json
     samples_by_locality = group_by_locality(SAMPLES)
-    with open("jsondata/geochronology.json", "r") as f:
+    with open(SITE_ROOT / "jsondata/geochronology.json", "r") as f:
         geodata = json.load(f)
+    with open(SITE_ROOT / "jsondata/taxonomy.json", "r") as f:
+        taxonomy_info = flatten_taxonomy_tree(Path("tree"), json.load(f))
+    taxonomy_info.append(("unclassified", unknown_taxon_dict))
+    taxonomy_info.sort()
+
     localities_info = geodata["localities"]
 
     for locality, samples in samples_by_locality.items():
@@ -274,8 +300,9 @@ def generate_locality_pages():
         if not html_file.exists():
             html_file.touch()
         template_html = JINJA_ENV.get_template("locality.html.template")
-        taxon_html = template_html.render(
-            samples_for_locality=samples,
+        locality_html = template_html.render(
+            samples_by_taxon=group_by_taxon(samples),
+            taxonomy_info=taxonomy_info,
             dir="/localities",
             root_relative_prefix="../",
             name_en=localities_info[locality]["name"]["en"],
@@ -285,20 +312,20 @@ def generate_locality_pages():
             description_paragraphs=len(localities_info[locality]["description"]["en"]),
             meta_description=truncate_meta_description(localities_info[locality]["description"]["en"][0])
         )
-        html_file.write_text(taxon_html)
+        html_file.write_text(locality_html)
 
         json_file = Path(f"localities/{locality}.json")
         if not json_file.exists():
             json_file.touch()
         template_json = JINJA_ENV.get_template("locality.json.template")
-        taxon_json = template_json.render(
+        locality_json = template_json.render(
             loc=localities_info[locality],
             samples=samples,
             to_grc_number=greek_numeral,
             globaldict=GLOBAL_DICT,
             loc_id=locality,
         )
-        json_file.write_text(taxon_json)
+        json_file.write_text(locality_json)
 
 if __name__ == "__main__":
     # tree/*/<taxon>.<html/json>

--- a/pyscripts/site_generator/templates/locality.html.template
+++ b/pyscripts/site_generator/templates/locality.html.template
@@ -66,70 +66,87 @@
             </section>
 
             {% set galleryns=namespace(img_counter=0, gallery_counter=0) -%}
-            <section id="{{loc_id}}-gallery">
-                <div class="tax-subcontainer">
-                    <div class="gallery" id="gallery-{{locality}}">
-                    {% for sample in samples_for_locality %}
-                        {% set galleryns.gallery_counter = galleryns.gallery_counter + 1 %}
-                        <div class="sample-box" onclick="openGallery({{ galleryns.gallery_counter }})">
-                            {% if sample.images|length == 1 %}
-                            <picture class="image-single">
-                                <source srcset="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[0].filename}}_thumb.webp 1x" type="image/webp">
-                                <img loading="lazy" src="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[0].filename}}_thumb.jpg" alt="{{sample.images[0].caption.en}}">
-                            </picture>
-                            {% elif sample.images|length == 2 %}
-                            <div class="image-two">
-                                <picture class="image-main">
-                                    <source srcset="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[0].filename}}_thumb.webp 1x" type="image/webp">
-                                    <img loading="lazy" src="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[0].filename}}_thumb.jpg" alt="{{sample.images[0].caption.en}}">
-                                </picture>
-                                <div class="image-overlay">+1</div>
-                            </div>
-                            {% else %}
-                            <div class="image-three">
-                                <div class="image-left">
+            {% for taxon_id, taxon_info in taxonomy_info -%}
+            {% if taxon_id in samples_by_taxon -%}
+                <section id="{{loc_id}}-{{taxon_id}}-gallery">
+                    <div class="tax-subcontainer">
+                        <a href="{{root_relative_prefix}}{{taxon_info["path"]}}" style="text-decoration: none;">
+                            <h1 id="{{taxon_id}}"></h1>
+                        </a>
+                        <div class="grid" id="gallery-{{locality}}">
+                            <div class="large">
+                                <a href="{{root_relative_prefix}}{{taxon_info["path"]}}">
                                     <picture>
+                                        <source srcset="{{root_relative_prefix}}images/thumbnails/webp_dir/{{taxon_info["name"]["el"].capitalize() | urlencode}}.webp 1x" type="image/webp">
+                                        <img loading="lazy" src="{{root_relative_prefix}}images/thumbnails/{{taxon_info["name"]["el"].capitalize()}}.jpg" alt="Artistic depiction of {{taxon_info["name"]["en"].capitalize()}}" id="{{loc_id}}-{{taxon_id}}-εικόνα">
+                                    </picture>
+                                </a>
+                            </div>
+                            {% for sample in samples_by_taxon[taxon_id] %}
+                            {% set galleryns.gallery_counter = galleryns.gallery_counter + 1 %}
+                            <div class="small">
+                                <div class="sample-box" onclick="openGallery({{ galleryns.gallery_counter }})">
+                                    {% if sample.images|length == 1 %}
+                                    <picture class="image-single">
                                         <source srcset="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[0].filename}}_thumb.webp 1x" type="image/webp">
                                         <img loading="lazy" src="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[0].filename}}_thumb.jpg" alt="{{sample.images[0].caption.en}}">
                                     </picture>
-                                </div>
-                                <div class="image-right">
-                                    <div class="image-top-right">
-                                        <picture>
-                                            <source srcset="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[1].filename}}_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[1].filename}}_thumb.jpg" alt="{{sample.images[1].caption.en}}">
+                                    {% elif sample.images|length == 2 %}
+                                    <div class="image-two">
+                                        <picture class="image-main">
+                                            <source srcset="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[0].filename}}_thumb.webp 1x" type="image/webp">
+                                            <img loading="lazy" src="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[0].filename}}_thumb.jpg" alt="{{sample.images[0].caption.en}}">
                                         </picture>
+                                        <div class="image-overlay">+1</div>
                                     </div>
-                                    <div class="image-bottom-right">
-                                        <picture>
-                                            <source srcset="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[2].filename}}_thumb.webp 1x" type="image/webp">
-                                            <img loading="lazy" src="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[2].filename}}_thumb.jpg" alt="{{sample.images[2].caption.en}}">
-                                        </picture>
-                                        {% if sample.images|length > 3 %}
-                                        <div class="image-overlay">+{{ sample.images|length - 3 }}</div>
-                                        {% endif %}
+                                    {% else %}
+                                    <div class="image-three">
+                                        <div class="image-left">
+                                            <picture>
+                                                <source srcset="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[0].filename}}_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[0].filename}}_thumb.jpg" alt="{{sample.images[0].caption.en}}">
+                                            </picture>
+                                        </div>
+                                        <div class="image-right">
+                                            <div class="image-top-right">
+                                                <picture>
+                                                    <source srcset="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[1].filename}}_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[1].filename}}_thumb.jpg" alt="{{sample.images[1].caption.en}}">
+                                                </picture>
+                                            </div>
+                                            <div class="image-bottom-right">
+                                                <picture>
+                                                    <source srcset="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[2].filename}}_thumb.webp 1x" type="image/webp">
+                                                    <img loading="lazy" src="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[2].filename}}_thumb.jpg" alt="{{sample.images[2].caption.en}}">
+                                                </picture>
+                                                {% if sample.images|length > 3 %}
+                                                <div class="image-overlay">+{{ sample.images|length - 3 }}</div>
+                                                {% endif %}
+                                            </div>
+                                        </div>
                                     </div>
-                                </div>
-                            </div>
-                            {% endif %}
+                                    {% endif %}
 
-                            <!-- Hidden gallery -->
-                            <div id="hidden-gallery-{{ galleryns.gallery_counter }}" style="display: none;">
-                                {% for img in sample.images %}
-                                {% set galleryns.img_counter = galleryns.img_counter + 1 %}
-                                <a href="{{root_relative_prefix}}{{sample.images_dir}}/{{sample.images[loop.index0].filename}}.jpg" id="gallery-img-{{galleryns.img_counter}}">
-                                    <picture>
-                                        <source srcset="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[loop.index0].filename}}_thumb.webp 1x" type="image/webp">
-                                        <img loading="lazy" src="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[loop.index0].filename}}_thumb.jpg" alt="{{sample.images[loop.index0].caption.en}}">
-                                    </picture>
-                                </a>
-                                {% endfor %}
+                                    <!-- Hidden gallery -->
+                                    <div id="hidden-gallery-{{ galleryns.gallery_counter }}" style="display: none;">
+                                        {% for img in sample.images %}
+                                        {% set galleryns.img_counter = galleryns.img_counter + 1 %}
+                                        <a href="{{root_relative_prefix}}{{sample.images_dir}}/{{sample.images[loop.index0].filename}}.jpg" id="gallery-img-{{galleryns.img_counter}}">
+                                            <picture>
+                                                <source srcset="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[loop.index0].filename}}_thumb.webp 1x" type="image/webp">
+                                                <img loading="lazy" src="{{root_relative_prefix}}{{sample.images_dir}}/thumbs_dir/{{sample.images[loop.index0].filename}}_thumb.jpg" alt="{{sample.images[loop.index0].caption.en}}">
+                                            </picture>
+                                        </a>
+                                        {% endfor %}
+                                    </div>
+                                </div>
                             </div>
+                            {% endfor %}
                         </div>
-                    {% endfor %}
                     </div>
-                </div>
-            </section>
+                </section>
+                {% endif -%}
+            {% endfor -%}
         </main>
     </div>
 
@@ -145,7 +162,7 @@
         id="language-script"
         src="{{root_relative_prefix}}scripts/language.js"
         dict="{{dir}}/{{loc_id}}.json"
-        keys="τίτλος,{{loc_id}}{% for i in range(description_paragraphs) %},{{loc_id}}-περιγραφή-{{i+1}}{% endfor %},age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,{{loc_id}}-formation,{{loc_id}}-depositional_environment,{{loc_id}}-fossil_types,{{loc_id}}-paleoecology_highlights,{% if loc.age.prefix is defined %}{{loc.age.prefix}},{% endif %}{{loc.age.period}},{% if loc.age.period_detail is defined %}{{loc.age.period_detail}},{% endif %}mya,longshore-drift-description"
+        keys="τίτλος,{{loc_id}}{% for i in range(description_paragraphs) %},{{loc_id}}-περιγραφή-{{i+1}}{% endfor %},age-label,period-label,formation-label,depositional_environment-label,fossil_types-label,paleoecology_highlights-label,{{loc_id}}-formation,{{loc_id}}-depositional_environment,{{loc_id}}-fossil_types,{{loc_id}}-paleoecology_highlights,{% if loc.age.prefix is defined %}{{loc.age.prefix}},{% endif %}{{loc.age.period}},{% if loc.age.period_detail is defined %}{{loc.age.period_detail}},{% endif %}{% for taxon_id in samples_by_taxon.keys() -%}{{taxon_id}},{% endfor %}{% if loc_id == "chapel-st-leonards" %}longshore-drift-description,{% endif %}mya"
         galleryLength="{{galleryns.img_counter}}"
     ></script>
 

--- a/pyscripts/site_generator/templates/taxon.html.template
+++ b/pyscripts/site_generator/templates/taxon.html.template
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="{{taxon_id}}"></h2>
                     <picture>
-                        <source srcset="{{root_relative_prefix}}images/thumbnails/webp_dir/{{name_el.capitalize()}}.webp 1x" type="image/webp">
+                        <source srcset="{{root_relative_prefix}}images/thumbnails/webp_dir/{{name_el.capitalize() | urlencode}}.webp 1x" type="image/webp">
                         <img loading="lazy" src="{{root_relative_prefix}}images/thumbnails/{{name_el.capitalize()}}.jpg" alt="{{name_en}}" class="tax-page-image" id="{{taxon_id}}-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -111,7 +111,7 @@
                         <a href="{{subtaxon_id}}/{{subtaxon_id}}.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="{{root_relative_prefix}}images/thumbnails/thumbs_dir/{{subtaxon_dict.name.el.capitalize()}}_thumb.webp 1x" type="image/webp">
+                                    <source srcset="{{root_relative_prefix}}images/thumbnails/thumbs_dir/{{subtaxon_dict.name.el.capitalize() | urlencode}}_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="{{root_relative_prefix}}images/thumbnails/thumbs_dir/{{subtaxon_dict.name.el.capitalize()}}_thumb.jpg" alt="{{subtaxon_dict.name.en}}" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="{{taxon_id}}-{{subtaxon_id}}"></h3>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -14,7 +14,7 @@
     </url>
   <url>
         <loc>https://apolithomata.com/map.html</loc>
-        <lastmod>2025-07-27</lastmod>
+        <lastmod>2025-07-28</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
@@ -92,7 +92,7 @@
     </url>
   <url>
         <loc>https://apolithomata.com/tree/animalia/mollusca/bivalvia/bivalvia.html</loc>
-        <lastmod>2025-07-27</lastmod>
+        <lastmod>2025-07-28</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
@@ -116,7 +116,7 @@
     </url>
   <url>
         <loc>https://apolithomata.com/tree/animalia/mollusca/bivalvia/autobranchia/ostreida/ostreida.html</loc>
-        <lastmod>2025-07-27</lastmod>
+        <lastmod>2025-07-28</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>

--- a/style.css
+++ b/style.css
@@ -403,16 +403,18 @@ header div {
 }
 
 .sample-box {
-  width: 200px;
-  height: 150px;
+  width: 100%;
+  height: auto;
+  max-height: 200px;
+  aspect-ratio: 1 / 1;
   position: relative;
   cursor: pointer;
   overflow: hidden;
-  border: 1px solid #ccc;
   margin: 10px;
+  box-shadow: 0 6px 6px rgba(0, 0, 0, 0.3);
 }
 
-.image-single {
+.image-single img {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -462,7 +464,6 @@ header div {
   width: 50%;
   display: flex;
   flex-direction: column;
-  border-left: 1px solid #ccc;
 }
 
 .image-top-right, .image-bottom-right {
@@ -523,4 +524,29 @@ header div {
   width: 100%;
   height: auto;
   display: block;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 12px;
+}
+
+.large {
+  grid-column: 1 / span 2;
+  grid-row: 1 / span 2;
+  aspect-ratio: 1 / 1;
+  width: 100%;
+}
+
+.large img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  box-sizing: border-box;
+  border: 2px solid #aaa;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  border-radius: 8px;
+
+  object-fit: cover;
 }

--- a/tree/animalia/animalia.html
+++ b/tree/animalia/animalia.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="animalia"></h2>
                     <picture>
-                        <source srcset="../../images/thumbnails/webp_dir/Ζώα.webp 1x" type="image/webp">
+                        <source srcset="../../images/thumbnails/webp_dir/%CE%96%CF%8E%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../images/thumbnails/Ζώα.jpg" alt="animalia" class="tax-page-image" id="animalia-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="chordata/chordata.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../images/thumbnails/thumbs_dir/Χορδωτά_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../images/thumbnails/thumbs_dir/%CE%A7%CE%BF%CF%81%CE%B4%CF%89%CF%84%CE%AC_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../images/thumbnails/thumbs_dir/Χορδωτά_thumb.jpg" alt="chordata" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="animalia-chordata"></h3>
@@ -45,7 +45,7 @@
                         <a href="echinodermata/echinodermata.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../images/thumbnails/thumbs_dir/Εχινόδερμα_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../images/thumbnails/thumbs_dir/%CE%95%CF%87%CE%B9%CE%BD%CF%8C%CE%B4%CE%B5%CF%81%CE%BC%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../images/thumbnails/thumbs_dir/Εχινόδερμα_thumb.jpg" alt="echinodermata" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="animalia-echinodermata"></h3>
@@ -54,7 +54,7 @@
                         <a href="mollusca/mollusca.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../images/thumbnails/thumbs_dir/Μαλάκια_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../images/thumbnails/thumbs_dir/%CE%9C%CE%B1%CE%BB%CE%AC%CE%BA%CE%B9%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../images/thumbnails/thumbs_dir/Μαλάκια_thumb.jpg" alt="mollusca" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="animalia-mollusca"></h3>
@@ -63,7 +63,7 @@
                         <a href="arthropoda/arthropoda.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../images/thumbnails/thumbs_dir/Αρθρόποδα_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../images/thumbnails/thumbs_dir/%CE%91%CF%81%CE%B8%CF%81%CF%8C%CF%80%CE%BF%CE%B4%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../images/thumbnails/thumbs_dir/Αρθρόποδα_thumb.jpg" alt="arthropoda" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="animalia-arthropoda"></h3>
@@ -72,7 +72,7 @@
                         <a href="cnidaria/cnidaria.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../images/thumbnails/thumbs_dir/Κνιδόζωα_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../images/thumbnails/thumbs_dir/%CE%9A%CE%BD%CE%B9%CE%B4%CF%8C%CE%B6%CF%89%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../images/thumbnails/thumbs_dir/Κνιδόζωα_thumb.jpg" alt="cnidaria" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="animalia-cnidaria"></h3>

--- a/tree/animalia/arthropoda/arthropoda.html
+++ b/tree/animalia/arthropoda/arthropoda.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="arthropoda"></h2>
                     <picture>
-                        <source srcset="../../../images/thumbnails/webp_dir/Αρθρόποδα.webp 1x" type="image/webp">
+                        <source srcset="../../../images/thumbnails/webp_dir/%CE%91%CF%81%CE%B8%CF%81%CF%8C%CF%80%CE%BF%CE%B4%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../images/thumbnails/Αρθρόποδα.jpg" alt="arthropoda" class="tax-page-image" id="arthropoda-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -37,7 +37,7 @@
                         <a href="trilobita/trilobita.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../images/thumbnails/thumbs_dir/Τριλοβίτες_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../images/thumbnails/thumbs_dir/%CE%A4%CF%81%CE%B9%CE%BB%CE%BF%CE%B2%CE%AF%CF%84%CE%B5%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../images/thumbnails/thumbs_dir/Τριλοβίτες_thumb.jpg" alt="trilobita" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="arthropoda-trilobita"></h3>

--- a/tree/animalia/arthropoda/trilobita/corynexochida/corynexochida.html
+++ b/tree/animalia/arthropoda/trilobita/corynexochida/corynexochida.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="corynexochida"></h2>
                     <picture>
-                        <source srcset="../../../../../images/thumbnails/webp_dir/Κορυνεξοχίδες.webp 1x" type="image/webp">
+                        <source srcset="../../../../../images/thumbnails/webp_dir/%CE%9A%CE%BF%CF%81%CF%85%CE%BD%CE%B5%CE%BE%CE%BF%CF%87%CE%AF%CE%B4%CE%B5%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../images/thumbnails/Κορυνεξοχίδες.jpg" alt="corynexochida" class="tax-page-image" id="corynexochida-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -38,7 +38,7 @@
                         <a href="paralejurus/paralejurus.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/Παραλεγιούρος_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/%CE%A0%CE%B1%CF%81%CE%B1%CE%BB%CE%B5%CE%B3%CE%B9%CE%BF%CF%8D%CF%81%CE%BF%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../images/thumbnails/thumbs_dir/Παραλεγιούρος_thumb.jpg" alt="paralejurus" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="corynexochida-paralejurus"></h3>

--- a/tree/animalia/arthropoda/trilobita/corynexochida/paralejurus/paralejurus.html
+++ b/tree/animalia/arthropoda/trilobita/corynexochida/paralejurus/paralejurus.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="paralejurus"></h2>
                     <picture>
-                        <source srcset="../../../../../../images/thumbnails/webp_dir/Παραλεγιούρος.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../images/thumbnails/webp_dir/%CE%A0%CE%B1%CF%81%CE%B1%CE%BB%CE%B5%CE%B3%CE%B9%CE%BF%CF%8D%CF%81%CE%BF%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../images/thumbnails/Παραλεγιούρος.jpg" alt="paralejurus" class="tax-page-image" id="paralejurus-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/tree/animalia/arthropoda/trilobita/phacopida/phacopida.html
+++ b/tree/animalia/arthropoda/trilobita/phacopida/phacopida.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="phacopida"></h2>
                     <picture>
-                        <source srcset="../../../../../images/thumbnails/webp_dir/Φακόπιδα.webp 1x" type="image/webp">
+                        <source srcset="../../../../../images/thumbnails/webp_dir/%CE%A6%CE%B1%CE%BA%CF%8C%CF%80%CE%B9%CE%B4%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../images/thumbnails/Φακόπιδα.jpg" alt="phacopida" class="tax-page-image" id="phacopida-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -38,7 +38,7 @@
                         <a href="reedops/reedops.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/Ρήδοπας_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/%CE%A1%CE%AE%CE%B4%CE%BF%CF%80%CE%B1%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../images/thumbnails/thumbs_dir/Ρήδοπας_thumb.jpg" alt="reedops" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="phacopida-reedops"></h3>
@@ -47,7 +47,7 @@
                         <a href="zlichovaspis/zlichovaspis.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/Ζλιχοβάσπις_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/%CE%96%CE%BB%CE%B9%CF%87%CE%BF%CE%B2%CE%AC%CF%83%CF%80%CE%B9%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../images/thumbnails/thumbs_dir/Ζλιχοβάσπις_thumb.jpg" alt="zlichovaspis" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="phacopida-zlichovaspis"></h3>

--- a/tree/animalia/arthropoda/trilobita/phacopida/reedops/reedops.html
+++ b/tree/animalia/arthropoda/trilobita/phacopida/reedops/reedops.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="reedops"></h2>
                     <picture>
-                        <source srcset="../../../../../../images/thumbnails/webp_dir/Ρήδοπας.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../images/thumbnails/webp_dir/%CE%A1%CE%AE%CE%B4%CE%BF%CF%80%CE%B1%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../images/thumbnails/Ρήδοπας.jpg" alt="reedops" class="tax-page-image" id="reedops-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -38,7 +38,7 @@
                         <a href="reedops_maurulus/reedops_maurulus.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/Ρήδοπας ο μαυρίσκος_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/%CE%A1%CE%AE%CE%B4%CE%BF%CF%80%CE%B1%CF%82%20%CE%BF%20%CE%BC%CE%B1%CF%85%CF%81%CE%AF%CF%83%CE%BA%CE%BF%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../images/thumbnails/thumbs_dir/Ρήδοπας ο μαυρίσκος_thumb.jpg" alt="reedops maurulus" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="reedops-reedops_maurulus"></h3>

--- a/tree/animalia/arthropoda/trilobita/phacopida/reedops/reedops_maurulus/reedops_maurulus.html
+++ b/tree/animalia/arthropoda/trilobita/phacopida/reedops/reedops_maurulus/reedops_maurulus.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="reedops_maurulus"></h2>
                     <picture>
-                        <source srcset="../../../../../../../images/thumbnails/webp_dir/Ρήδοπας ο μαυρίσκος.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../images/thumbnails/webp_dir/%CE%A1%CE%AE%CE%B4%CE%BF%CF%80%CE%B1%CF%82%20%CE%BF%20%CE%BC%CE%B1%CF%85%CF%81%CE%AF%CF%83%CE%BA%CE%BF%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../images/thumbnails/Ρήδοπας ο μαυρίσκος.jpg" alt="reedops maurulus" class="tax-page-image" id="reedops_maurulus-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/tree/animalia/arthropoda/trilobita/phacopida/zlichovaspis/zlichovaspis.html
+++ b/tree/animalia/arthropoda/trilobita/phacopida/zlichovaspis/zlichovaspis.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="zlichovaspis"></h2>
                     <picture>
-                        <source srcset="../../../../../../images/thumbnails/webp_dir/Ζλιχοβάσπις.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../images/thumbnails/webp_dir/%CE%96%CE%BB%CE%B9%CF%87%CE%BF%CE%B2%CE%AC%CF%83%CF%80%CE%B9%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../images/thumbnails/Ζλιχοβάσπις.jpg" alt="zlichovaspis" class="tax-page-image" id="zlichovaspis-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/tree/animalia/arthropoda/trilobita/trilobita.html
+++ b/tree/animalia/arthropoda/trilobita/trilobita.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="trilobita"></h2>
                     <picture>
-                        <source srcset="../../../../images/thumbnails/webp_dir/Τριλοβίτες.webp 1x" type="image/webp">
+                        <source srcset="../../../../images/thumbnails/webp_dir/%CE%A4%CF%81%CE%B9%CE%BB%CE%BF%CE%B2%CE%AF%CF%84%CE%B5%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../images/thumbnails/Τριλοβίτες.jpg" alt="trilobita" class="tax-page-image" id="trilobita-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="phacopida/phacopida.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../images/thumbnails/thumbs_dir/Φακόπιδα_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../images/thumbnails/thumbs_dir/%CE%A6%CE%B1%CE%BA%CF%8C%CF%80%CE%B9%CE%B4%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../images/thumbnails/thumbs_dir/Φακόπιδα_thumb.jpg" alt="phacopida" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="trilobita-phacopida"></h3>
@@ -45,7 +45,7 @@
                         <a href="corynexochida/corynexochida.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../images/thumbnails/thumbs_dir/Κορυνεξοχίδες_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../images/thumbnails/thumbs_dir/%CE%9A%CE%BF%CF%81%CF%85%CE%BD%CE%B5%CE%BE%CE%BF%CF%87%CE%AF%CE%B4%CE%B5%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../images/thumbnails/thumbs_dir/Κορυνεξοχίδες_thumb.jpg" alt="corynexochida" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="trilobita-corynexochida"></h3>

--- a/tree/animalia/chordata/chondrichthyes/chondrichthyes.html
+++ b/tree/animalia/chordata/chondrichthyes/chondrichthyes.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="chondrichthyes"></h2>
                     <picture>
-                        <source srcset="../../../../images/thumbnails/webp_dir/Χονδριχθύες.webp 1x" type="image/webp">
+                        <source srcset="../../../../images/thumbnails/webp_dir/%CE%A7%CE%BF%CE%BD%CE%B4%CF%81%CE%B9%CF%87%CE%B8%CF%8D%CE%B5%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../images/thumbnails/Χονδριχθύες.jpg" alt="chondrichthyes" class="tax-page-image" id="chondrichthyes-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="elasmobranchii/elasmobranchii.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../images/thumbnails/thumbs_dir/Ελασμοβράγχιοι_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../images/thumbnails/thumbs_dir/%CE%95%CE%BB%CE%B1%CF%83%CE%BC%CE%BF%CE%B2%CF%81%CE%AC%CE%B3%CF%87%CE%B9%CE%BF%CE%B9_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../images/thumbnails/thumbs_dir/Ελασμοβράγχιοι_thumb.jpg" alt="elasmobranchii" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="chondrichthyes-elasmobranchii"></h3>

--- a/tree/animalia/chordata/chondrichthyes/elasmobranchii/dasyatidae/dasyatidae.html
+++ b/tree/animalia/chordata/chondrichthyes/elasmobranchii/dasyatidae/dasyatidae.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="dasyatidae"></h2>
                     <picture>
-                        <source srcset="../../../../../../images/thumbnails/webp_dir/Δασυατίδες.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../images/thumbnails/webp_dir/%CE%94%CE%B1%CF%83%CF%85%CE%B1%CF%84%CE%AF%CE%B4%CE%B5%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../images/thumbnails/Δασυατίδες.jpg" alt="dasyatidae" class="tax-page-image" id="dasyatidae-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="hypolophodon/hypolophodon.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/Υπολοφόδων_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/%CE%A5%CF%80%CE%BF%CE%BB%CE%BF%CF%86%CF%8C%CE%B4%CF%89%CE%BD_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../images/thumbnails/thumbs_dir/Υπολοφόδων_thumb.jpg" alt="hypolophodon" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="dasyatidae-hypolophodon"></h3>

--- a/tree/animalia/chordata/chondrichthyes/elasmobranchii/dasyatidae/hypolophodon/hypolophodon.html
+++ b/tree/animalia/chordata/chondrichthyes/elasmobranchii/dasyatidae/hypolophodon/hypolophodon.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="hypolophodon"></h2>
                     <picture>
-                        <source srcset="../../../../../../../images/thumbnails/webp_dir/Υπολοφόδων.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../images/thumbnails/webp_dir/%CE%A5%CF%80%CE%BF%CE%BB%CE%BF%CF%86%CF%8C%CE%B4%CF%89%CE%BD.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../images/thumbnails/Υπολοφόδων.jpg" alt="hypolophodon" class="tax-page-image" id="hypolophodon-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="hypolophodon_sylvestris/hypolophodon_sylvestris.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../../images/thumbnails/thumbs_dir/Υπολοφόδων ο δρυμώδης_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../../images/thumbnails/thumbs_dir/%CE%A5%CF%80%CE%BF%CE%BB%CE%BF%CF%86%CF%8C%CE%B4%CF%89%CE%BD%20%CE%BF%20%CE%B4%CF%81%CF%85%CE%BC%CF%8E%CE%B4%CE%B7%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../../images/thumbnails/thumbs_dir/Υπολοφόδων ο δρυμώδης_thumb.jpg" alt="hypolophodon sylvestris" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="hypolophodon-hypolophodon_sylvestris"></h3>

--- a/tree/animalia/chordata/chondrichthyes/elasmobranchii/dasyatidae/hypolophodon/hypolophodon_sylvestris/hypolophodon_sylvestris.html
+++ b/tree/animalia/chordata/chondrichthyes/elasmobranchii/dasyatidae/hypolophodon/hypolophodon_sylvestris/hypolophodon_sylvestris.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="hypolophodon_sylvestris"></h2>
                     <picture>
-                        <source srcset="../../../../../../../../images/thumbnails/webp_dir/Υπολοφόδων ο δρυμώδης.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../../images/thumbnails/webp_dir/%CE%A5%CF%80%CE%BF%CE%BB%CE%BF%CF%86%CF%8C%CE%B4%CF%89%CE%BD%20%CE%BF%20%CE%B4%CF%81%CF%85%CE%BC%CF%8E%CE%B4%CE%B7%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../../images/thumbnails/Υπολοφόδων ο δρυμώδης.jpg" alt="hypolophodon sylvestris" class="tax-page-image" id="hypolophodon_sylvestris-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/tree/animalia/chordata/chondrichthyes/elasmobranchii/elasmobranchii.html
+++ b/tree/animalia/chordata/chondrichthyes/elasmobranchii/elasmobranchii.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="elasmobranchii"></h2>
                     <picture>
-                        <source srcset="../../../../../images/thumbnails/webp_dir/Ελασμοβράγχιοι.webp 1x" type="image/webp">
+                        <source srcset="../../../../../images/thumbnails/webp_dir/%CE%95%CE%BB%CE%B1%CF%83%CE%BC%CE%BF%CE%B2%CF%81%CE%AC%CE%B3%CF%87%CE%B9%CE%BF%CE%B9.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../images/thumbnails/Ελασμοβράγχιοι.jpg" alt="elasmobranchii" class="tax-page-image" id="elasmobranchii-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="dasyatidae/dasyatidae.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/Δασυατίδες_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/%CE%94%CE%B1%CF%83%CF%85%CE%B1%CF%84%CE%AF%CE%B4%CE%B5%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../images/thumbnails/thumbs_dir/Δασυατίδες_thumb.jpg" alt="dasyatidae" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="elasmobranchii-dasyatidae"></h3>
@@ -45,7 +45,7 @@
                         <a href="odontaspididae/odontaspididae.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/Οδοντασπιδίδες_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/%CE%9F%CE%B4%CE%BF%CE%BD%CF%84%CE%B1%CF%83%CF%80%CE%B9%CE%B4%CE%AF%CE%B4%CE%B5%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../images/thumbnails/thumbs_dir/Οδοντασπιδίδες_thumb.jpg" alt="odontaspididae" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="elasmobranchii-odontaspididae"></h3>

--- a/tree/animalia/chordata/chondrichthyes/elasmobranchii/odontaspididae/odontaspididae.html
+++ b/tree/animalia/chordata/chondrichthyes/elasmobranchii/odontaspididae/odontaspididae.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="odontaspididae"></h2>
                     <picture>
-                        <source srcset="../../../../../../images/thumbnails/webp_dir/Οδοντασπιδίδες.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../images/thumbnails/webp_dir/%CE%9F%CE%B4%CE%BF%CE%BD%CF%84%CE%B1%CF%83%CF%80%CE%B9%CE%B4%CE%AF%CE%B4%CE%B5%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../images/thumbnails/Οδοντασπιδίδες.jpg" alt="odontaspididae" class="tax-page-image" id="odontaspididae-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="striatolamia/striatolamia.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/Στριατολάμια_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/%CE%A3%CF%84%CF%81%CE%B9%CE%B1%CF%84%CE%BF%CE%BB%CE%AC%CE%BC%CE%B9%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../images/thumbnails/thumbs_dir/Στριατολάμια_thumb.jpg" alt="striatolamia" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="odontaspididae-striatolamia"></h3>
@@ -45,7 +45,7 @@
                         <a href="sylvestrilamia/sylvestrilamia.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/Συλβεστριλάμια_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/%CE%A3%CF%85%CE%BB%CE%B2%CE%B5%CF%83%CF%84%CF%81%CE%B9%CE%BB%CE%AC%CE%BC%CE%B9%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../images/thumbnails/thumbs_dir/Συλβεστριλάμια_thumb.jpg" alt="sylvestrilamia" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="odontaspididae-sylvestrilamia"></h3>

--- a/tree/animalia/chordata/chondrichthyes/elasmobranchii/odontaspididae/striatolamia/striatolamia.html
+++ b/tree/animalia/chordata/chondrichthyes/elasmobranchii/odontaspididae/striatolamia/striatolamia.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="striatolamia"></h2>
                     <picture>
-                        <source srcset="../../../../../../../images/thumbnails/webp_dir/Στριατολάμια.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../images/thumbnails/webp_dir/%CE%A3%CF%84%CF%81%CE%B9%CE%B1%CF%84%CE%BF%CE%BB%CE%AC%CE%BC%CE%B9%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../images/thumbnails/Στριατολάμια.jpg" alt="striatolamia" class="tax-page-image" id="striatolamia-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="striatolamia_macrota/striatolamia_macrota.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../../images/thumbnails/thumbs_dir/Στριατολάμια η μακρά_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../../images/thumbnails/thumbs_dir/%CE%A3%CF%84%CF%81%CE%B9%CE%B1%CF%84%CE%BF%CE%BB%CE%AC%CE%BC%CE%B9%CE%B1%20%CE%B7%20%CE%BC%CE%B1%CE%BA%CF%81%CE%AC_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../../images/thumbnails/thumbs_dir/Στριατολάμια η μακρά_thumb.jpg" alt="striatolamia macrota" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="striatolamia-striatolamia_macrota"></h3>

--- a/tree/animalia/chordata/chondrichthyes/elasmobranchii/odontaspididae/striatolamia/striatolamia_macrota/striatolamia_macrota.html
+++ b/tree/animalia/chordata/chondrichthyes/elasmobranchii/odontaspididae/striatolamia/striatolamia_macrota/striatolamia_macrota.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="striatolamia_macrota"></h2>
                     <picture>
-                        <source srcset="../../../../../../../../images/thumbnails/webp_dir/Στριατολάμια η μακρά.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../../images/thumbnails/webp_dir/%CE%A3%CF%84%CF%81%CE%B9%CE%B1%CF%84%CE%BF%CE%BB%CE%AC%CE%BC%CE%B9%CE%B1%20%CE%B7%20%CE%BC%CE%B1%CE%BA%CF%81%CE%AC.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../../images/thumbnails/Στριατολάμια η μακρά.jpg" alt="striatolamia macrota" class="tax-page-image" id="striatolamia_macrota-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/tree/animalia/chordata/chondrichthyes/elasmobranchii/odontaspididae/sylvestrilamia/sylvestrilamia.html
+++ b/tree/animalia/chordata/chondrichthyes/elasmobranchii/odontaspididae/sylvestrilamia/sylvestrilamia.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="sylvestrilamia"></h2>
                     <picture>
-                        <source srcset="../../../../../../../images/thumbnails/webp_dir/Συλβεστριλάμια.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../images/thumbnails/webp_dir/%CE%A3%CF%85%CE%BB%CE%B2%CE%B5%CF%83%CF%84%CF%81%CE%B9%CE%BB%CE%AC%CE%BC%CE%B9%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../images/thumbnails/Συλβεστριλάμια.jpg" alt="sylvestrilamia" class="tax-page-image" id="sylvestrilamia-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -38,7 +38,7 @@
                         <a href="sylvestrilamia_teretidens/sylvestrilamia_teretidens.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../../images/thumbnails/thumbs_dir/Συλβεστριλάμια η λειόδους_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../../images/thumbnails/thumbs_dir/%CE%A3%CF%85%CE%BB%CE%B2%CE%B5%CF%83%CF%84%CF%81%CE%B9%CE%BB%CE%AC%CE%BC%CE%B9%CE%B1%20%CE%B7%20%CE%BB%CE%B5%CE%B9%CF%8C%CE%B4%CE%BF%CF%85%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../../images/thumbnails/thumbs_dir/Συλβεστριλάμια η λειόδους_thumb.jpg" alt="sylvestrilamia teretidens" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="sylvestrilamia-sylvestrilamia_teretidens"></h3>

--- a/tree/animalia/chordata/chondrichthyes/elasmobranchii/odontaspididae/sylvestrilamia/sylvestrilamia_teretidens/sylvestrilamia_teretidens.html
+++ b/tree/animalia/chordata/chondrichthyes/elasmobranchii/odontaspididae/sylvestrilamia/sylvestrilamia_teretidens/sylvestrilamia_teretidens.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="sylvestrilamia_teretidens"></h2>
                     <picture>
-                        <source srcset="../../../../../../../../images/thumbnails/webp_dir/Συλβεστριλάμια η λειόδους.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../../images/thumbnails/webp_dir/%CE%A3%CF%85%CE%BB%CE%B2%CE%B5%CF%83%CF%84%CF%81%CE%B9%CE%BB%CE%AC%CE%BC%CE%B9%CE%B1%20%CE%B7%20%CE%BB%CE%B5%CE%B9%CF%8C%CE%B4%CE%BF%CF%85%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../../images/thumbnails/Συλβεστριλάμια η λειόδους.jpg" alt="sylvestrilamia teretidens" class="tax-page-image" id="sylvestrilamia_teretidens-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/tree/animalia/chordata/chordata.html
+++ b/tree/animalia/chordata/chordata.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="chordata"></h2>
                     <picture>
-                        <source srcset="../../../images/thumbnails/webp_dir/Χορδωτά.webp 1x" type="image/webp">
+                        <source srcset="../../../images/thumbnails/webp_dir/%CE%A7%CE%BF%CF%81%CE%B4%CF%89%CF%84%CE%AC.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../images/thumbnails/Χορδωτά.jpg" alt="chordata" class="tax-page-image" id="chordata-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -655,7 +655,7 @@
                         <a href="chondrichthyes/chondrichthyes.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../images/thumbnails/thumbs_dir/Χονδριχθύες_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../images/thumbnails/thumbs_dir/%CE%A7%CE%BF%CE%BD%CE%B4%CF%81%CE%B9%CF%87%CE%B8%CF%8D%CE%B5%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../images/thumbnails/thumbs_dir/Χονδριχθύες_thumb.jpg" alt="chondrichthyes" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="chordata-chondrichthyes"></h3>
@@ -664,7 +664,7 @@
                         <a href="osteichthyes/osteichthyes.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../images/thumbnails/thumbs_dir/Οστεϊχθύες_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../images/thumbnails/thumbs_dir/%CE%9F%CF%83%CF%84%CE%B5%CF%8A%CF%87%CE%B8%CF%8D%CE%B5%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../images/thumbnails/thumbs_dir/Οστεϊχθύες_thumb.jpg" alt="osteichthyes" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="chordata-osteichthyes"></h3>

--- a/tree/animalia/chordata/osteichthyes/actinopterygii/actinopterygii.html
+++ b/tree/animalia/chordata/osteichthyes/actinopterygii/actinopterygii.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="actinopterygii"></h2>
                     <picture>
-                        <source srcset="../../../../../images/thumbnails/webp_dir/Ακτινοπτερύγιοι.webp 1x" type="image/webp">
+                        <source srcset="../../../../../images/thumbnails/webp_dir/%CE%91%CE%BA%CF%84%CE%B9%CE%BD%CE%BF%CF%80%CF%84%CE%B5%CF%81%CF%8D%CE%B3%CE%B9%CE%BF%CE%B9.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../images/thumbnails/Ακτινοπτερύγιοι.jpg" alt="actinopterygii" class="tax-page-image" id="actinopterygii-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -185,7 +185,7 @@
                         <a href="lepisosteidae/lepisosteidae.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/Λεπιδοστεΐδες_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/%CE%9B%CE%B5%CF%80%CE%B9%CE%B4%CE%BF%CF%83%CF%84%CE%B5%CE%90%CE%B4%CE%B5%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../images/thumbnails/thumbs_dir/Λεπιδοστεΐδες_thumb.jpg" alt="lepisosteidae" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="actinopterygii-lepisosteidae"></h3>

--- a/tree/animalia/chordata/osteichthyes/actinopterygii/lepisosteidae/lepisosteidae.html
+++ b/tree/animalia/chordata/osteichthyes/actinopterygii/lepisosteidae/lepisosteidae.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="lepisosteidae"></h2>
                     <picture>
-                        <source srcset="../../../../../../images/thumbnails/webp_dir/Λεπιδοστεΐδες.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../images/thumbnails/webp_dir/%CE%9B%CE%B5%CF%80%CE%B9%CE%B4%CE%BF%CF%83%CF%84%CE%B5%CE%90%CE%B4%CE%B5%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../images/thumbnails/Λεπιδοστεΐδες.jpg" alt="lepisosteidae" class="tax-page-image" id="lepisosteidae-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="lepisosteus/lepisosteus.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/Λεπιδόστεος_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/%CE%9B%CE%B5%CF%80%CE%B9%CE%B4%CF%8C%CF%83%CF%84%CE%B5%CE%BF%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../images/thumbnails/thumbs_dir/Λεπιδόστεος_thumb.jpg" alt="lepisosteus" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="lepisosteidae-lepisosteus"></h3>

--- a/tree/animalia/chordata/osteichthyes/actinopterygii/lepisosteidae/lepisosteus/lepisosteus.html
+++ b/tree/animalia/chordata/osteichthyes/actinopterygii/lepisosteidae/lepisosteus/lepisosteus.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="lepisosteus"></h2>
                     <picture>
-                        <source srcset="../../../../../../../images/thumbnails/webp_dir/Λεπιδόστεος.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../images/thumbnails/webp_dir/%CE%9B%CE%B5%CF%80%CE%B9%CE%B4%CF%8C%CF%83%CF%84%CE%B5%CE%BF%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../images/thumbnails/Λεπιδόστεος.jpg" alt="lepisosteus" class="tax-page-image" id="lepisosteus-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="lepisosteus_fimbriatus/lepisosteus_fimbriatus.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../../images/thumbnails/thumbs_dir/Λεπιδόστεος ο κροσσωτός_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../../images/thumbnails/thumbs_dir/%CE%9B%CE%B5%CF%80%CE%B9%CE%B4%CF%8C%CF%83%CF%84%CE%B5%CE%BF%CF%82%20%CE%BF%20%CE%BA%CF%81%CE%BF%CF%83%CF%83%CF%89%CF%84%CF%8C%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../../images/thumbnails/thumbs_dir/Λεπιδόστεος ο κροσσωτός_thumb.jpg" alt="lepisosteus fimbriatus" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="lepisosteus-lepisosteus_fimbriatus"></h3>

--- a/tree/animalia/chordata/osteichthyes/actinopterygii/lepisosteidae/lepisosteus/lepisosteus_fimbriatus/lepisosteus_fimbriatus.html
+++ b/tree/animalia/chordata/osteichthyes/actinopterygii/lepisosteidae/lepisosteus/lepisosteus_fimbriatus/lepisosteus_fimbriatus.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="lepisosteus_fimbriatus"></h2>
                     <picture>
-                        <source srcset="../../../../../../../../images/thumbnails/webp_dir/Λεπιδόστεος ο κροσσωτός.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../../images/thumbnails/webp_dir/%CE%9B%CE%B5%CF%80%CE%B9%CE%B4%CF%8C%CF%83%CF%84%CE%B5%CE%BF%CF%82%20%CE%BF%20%CE%BA%CF%81%CE%BF%CF%83%CF%83%CF%89%CF%84%CF%8C%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../../images/thumbnails/Λεπιδόστεος ο κροσσωτός.jpg" alt="lepisosteus fimbriatus" class="tax-page-image" id="lepisosteus_fimbriatus-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/tree/animalia/chordata/osteichthyes/osteichthyes.html
+++ b/tree/animalia/chordata/osteichthyes/osteichthyes.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="osteichthyes"></h2>
                     <picture>
-                        <source srcset="../../../../images/thumbnails/webp_dir/Οστεϊχθύες.webp 1x" type="image/webp">
+                        <source srcset="../../../../images/thumbnails/webp_dir/%CE%9F%CF%83%CF%84%CE%B5%CF%8A%CF%87%CE%B8%CF%8D%CE%B5%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../images/thumbnails/Οστεϊχθύες.jpg" alt="osteichthyes" class="tax-page-image" id="osteichthyes-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="actinopterygii/actinopterygii.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../images/thumbnails/thumbs_dir/Ακτινοπτερύγιοι_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../images/thumbnails/thumbs_dir/%CE%91%CE%BA%CF%84%CE%B9%CE%BD%CE%BF%CF%80%CF%84%CE%B5%CF%81%CF%8D%CE%B3%CE%B9%CE%BF%CE%B9_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../images/thumbnails/thumbs_dir/Ακτινοπτερύγιοι_thumb.jpg" alt="actinopterygii" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="osteichthyes-actinopterygii"></h3>
@@ -45,7 +45,7 @@
                         <a href="sarcopterygii/sarcopterygii.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../images/thumbnails/thumbs_dir/Σαρκοπτερύγιοι_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../images/thumbnails/thumbs_dir/%CE%A3%CE%B1%CF%81%CE%BA%CE%BF%CF%80%CF%84%CE%B5%CF%81%CF%8D%CE%B3%CE%B9%CE%BF%CE%B9_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../images/thumbnails/thumbs_dir/Σαρκοπτερύγιοι_thumb.jpg" alt="sarcopterygii" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="osteichthyes-sarcopterygii"></h3>

--- a/tree/animalia/chordata/osteichthyes/sarcopterygii/sarcopterygii.html
+++ b/tree/animalia/chordata/osteichthyes/sarcopterygii/sarcopterygii.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="sarcopterygii"></h2>
                     <picture>
-                        <source srcset="../../../../../images/thumbnails/webp_dir/Σαρκοπτερύγιοι.webp 1x" type="image/webp">
+                        <source srcset="../../../../../images/thumbnails/webp_dir/%CE%A3%CE%B1%CF%81%CE%BA%CE%BF%CF%80%CF%84%CE%B5%CF%81%CF%8D%CE%B3%CE%B9%CE%BF%CE%B9.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../images/thumbnails/Σαρκοπτερύγιοι.jpg" alt="sarcopterygii" class="tax-page-image" id="sarcopterygii-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -38,7 +38,7 @@
                         <a href="sauropsida/sauropsida.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/Σαυρόψιδα_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/%CE%A3%CE%B1%CF%85%CF%81%CF%8C%CF%88%CE%B9%CE%B4%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../images/thumbnails/thumbs_dir/Σαυρόψιδα_thumb.jpg" alt="sauropsida" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="sarcopterygii-sauropsida"></h3>

--- a/tree/animalia/chordata/osteichthyes/sarcopterygii/sauropsida/dinosauria/dinosauria.html
+++ b/tree/animalia/chordata/osteichthyes/sarcopterygii/sauropsida/dinosauria/dinosauria.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="dinosauria"></h2>
                     <picture>
-                        <source srcset="../../../../../../../images/thumbnails/webp_dir/Δεινοσαύρια.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../images/thumbnails/webp_dir/%CE%94%CE%B5%CE%B9%CE%BD%CE%BF%CF%83%CE%B1%CF%8D%CF%81%CE%B9%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../images/thumbnails/Δεινοσαύρια.jpg" alt="dinosauria" class="tax-page-image" id="dinosauria-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -39,7 +39,7 @@
                         <a href="theropoda/theropoda.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../../images/thumbnails/thumbs_dir/Θηριόποδα_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../../images/thumbnails/thumbs_dir/%CE%98%CE%B7%CF%81%CE%B9%CF%8C%CF%80%CE%BF%CE%B4%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../../images/thumbnails/thumbs_dir/Θηριόποδα_thumb.jpg" alt="theropoda" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="dinosauria-theropoda"></h3>

--- a/tree/animalia/chordata/osteichthyes/sarcopterygii/sauropsida/dinosauria/theropoda/aves/aves.html
+++ b/tree/animalia/chordata/osteichthyes/sarcopterygii/sauropsida/dinosauria/theropoda/aves/aves.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="aves"></h2>
                     <picture>
-                        <source srcset="../../../../../../../../../images/thumbnails/webp_dir/Πτηνά.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../../../images/thumbnails/webp_dir/%CE%A0%CF%84%CE%B7%CE%BD%CE%AC.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../../../images/thumbnails/Πτηνά.jpg" alt="aves" class="tax-page-image" id="aves-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/tree/animalia/chordata/osteichthyes/sarcopterygii/sauropsida/dinosauria/theropoda/spinosauridae/spinosauridae.html
+++ b/tree/animalia/chordata/osteichthyes/sarcopterygii/sauropsida/dinosauria/theropoda/spinosauridae/spinosauridae.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="spinosauridae"></h2>
                     <picture>
-                        <source srcset="../../../../../../../../../images/thumbnails/webp_dir/Σπινοσαυρίδες.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../../../images/thumbnails/webp_dir/%CE%A3%CF%80%CE%B9%CE%BD%CE%BF%CF%83%CE%B1%CF%85%CF%81%CE%AF%CE%B4%CE%B5%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../../../images/thumbnails/Σπινοσαυρίδες.jpg" alt="spinosauridae" class="tax-page-image" id="spinosauridae-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -38,7 +38,7 @@
                         <a href="spinosaurus/spinosaurus.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../../../../images/thumbnails/thumbs_dir/Σπινόσαυρος_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../../../../images/thumbnails/thumbs_dir/%CE%A3%CF%80%CE%B9%CE%BD%CF%8C%CF%83%CE%B1%CF%85%CF%81%CE%BF%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../../../../images/thumbnails/thumbs_dir/Σπινόσαυρος_thumb.jpg" alt="spinosaurus" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="spinosauridae-spinosaurus"></h3>

--- a/tree/animalia/chordata/osteichthyes/sarcopterygii/sauropsida/dinosauria/theropoda/spinosauridae/spinosaurus/spinosaurus.html
+++ b/tree/animalia/chordata/osteichthyes/sarcopterygii/sauropsida/dinosauria/theropoda/spinosauridae/spinosaurus/spinosaurus.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="spinosaurus"></h2>
                     <picture>
-                        <source srcset="../../../../../../../../../../images/thumbnails/webp_dir/Σπινόσαυρος.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../../../../images/thumbnails/webp_dir/%CE%A3%CF%80%CE%B9%CE%BD%CF%8C%CF%83%CE%B1%CF%85%CF%81%CE%BF%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../../../../images/thumbnails/Σπινόσαυρος.jpg" alt="spinosaurus" class="tax-page-image" id="spinosaurus-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/tree/animalia/chordata/osteichthyes/sarcopterygii/sauropsida/dinosauria/theropoda/theropoda.html
+++ b/tree/animalia/chordata/osteichthyes/sarcopterygii/sauropsida/dinosauria/theropoda/theropoda.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="theropoda"></h2>
                     <picture>
-                        <source srcset="../../../../../../../../images/thumbnails/webp_dir/Θηριόποδα.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../../images/thumbnails/webp_dir/%CE%98%CE%B7%CF%81%CE%B9%CF%8C%CF%80%CE%BF%CE%B4%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../../images/thumbnails/Θηριόποδα.jpg" alt="theropoda" class="tax-page-image" id="theropoda-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -39,7 +39,7 @@
                         <a href="aves/aves.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../../../images/thumbnails/thumbs_dir/Πτηνά_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../../../images/thumbnails/thumbs_dir/%CE%A0%CF%84%CE%B7%CE%BD%CE%AC_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../../../images/thumbnails/thumbs_dir/Πτηνά_thumb.jpg" alt="aves" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="theropoda-aves"></h3>
@@ -48,7 +48,7 @@
                         <a href="spinosauridae/spinosauridae.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../../../images/thumbnails/thumbs_dir/Σπινοσαυρίδες_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../../../images/thumbnails/thumbs_dir/%CE%A3%CF%80%CE%B9%CE%BD%CE%BF%CF%83%CE%B1%CF%85%CF%81%CE%AF%CE%B4%CE%B5%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../../../images/thumbnails/thumbs_dir/Σπινοσαυρίδες_thumb.jpg" alt="spinosauridae" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="theropoda-spinosauridae"></h3>

--- a/tree/animalia/chordata/osteichthyes/sarcopterygii/sauropsida/sauropsida.html
+++ b/tree/animalia/chordata/osteichthyes/sarcopterygii/sauropsida/sauropsida.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="sauropsida"></h2>
                     <picture>
-                        <source srcset="../../../../../../images/thumbnails/webp_dir/Σαυρόψιδα.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../images/thumbnails/webp_dir/%CE%A3%CE%B1%CF%85%CF%81%CF%8C%CF%88%CE%B9%CE%B4%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../images/thumbnails/Σαυρόψιδα.jpg" alt="sauropsida" class="tax-page-image" id="sauropsida-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -39,7 +39,7 @@
                         <a href="dinosauria/dinosauria.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/Δεινοσαύρια_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/%CE%94%CE%B5%CE%B9%CE%BD%CE%BF%CF%83%CE%B1%CF%8D%CF%81%CE%B9%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../images/thumbnails/thumbs_dir/Δεινοσαύρια_thumb.jpg" alt="dinosauria" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="sauropsida-dinosauria"></h3>

--- a/tree/animalia/cnidaria/anthozoa/anthozoa.html
+++ b/tree/animalia/cnidaria/anthozoa/anthozoa.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="anthozoa"></h2>
                     <picture>
-                        <source srcset="../../../../images/thumbnails/webp_dir/Ανθόζωα.webp 1x" type="image/webp">
+                        <source srcset="../../../../images/thumbnails/webp_dir/%CE%91%CE%BD%CE%B8%CF%8C%CE%B6%CF%89%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../images/thumbnails/Ανθόζωα.jpg" alt="anthozoa" class="tax-page-image" id="anthozoa-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -134,7 +134,7 @@
                         <a href="rugosa/rugosa.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../images/thumbnails/thumbs_dir/Ρυτιδωτά_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../images/thumbnails/thumbs_dir/%CE%A1%CF%85%CF%84%CE%B9%CE%B4%CF%89%CF%84%CE%AC_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../images/thumbnails/thumbs_dir/Ρυτιδωτά_thumb.jpg" alt="rugosa" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="anthozoa-rugosa"></h3>

--- a/tree/animalia/cnidaria/anthozoa/rugosa/rugosa.html
+++ b/tree/animalia/cnidaria/anthozoa/rugosa/rugosa.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="rugosa"></h2>
                     <picture>
-                        <source srcset="../../../../../images/thumbnails/webp_dir/Ρυτιδωτά.webp 1x" type="image/webp">
+                        <source srcset="../../../../../images/thumbnails/webp_dir/%CE%A1%CF%85%CF%84%CE%B9%CE%B4%CF%89%CF%84%CE%AC.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../images/thumbnails/Ρυτιδωτά.jpg" alt="rugosa" class="tax-page-image" id="rugosa-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/tree/animalia/cnidaria/cnidaria.html
+++ b/tree/animalia/cnidaria/cnidaria.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="cnidaria"></h2>
                     <picture>
-                        <source srcset="../../../images/thumbnails/webp_dir/Κνιδόζωα.webp 1x" type="image/webp">
+                        <source srcset="../../../images/thumbnails/webp_dir/%CE%9A%CE%BD%CE%B9%CE%B4%CF%8C%CE%B6%CF%89%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../images/thumbnails/Κνιδόζωα.jpg" alt="cnidaria" class="tax-page-image" id="cnidaria-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -38,7 +38,7 @@
                         <a href="anthozoa/anthozoa.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../images/thumbnails/thumbs_dir/Ανθόζωα_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../images/thumbnails/thumbs_dir/%CE%91%CE%BD%CE%B8%CF%8C%CE%B6%CF%89%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../images/thumbnails/thumbs_dir/Ανθόζωα_thumb.jpg" alt="anthozoa" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="cnidaria-anthozoa"></h3>

--- a/tree/animalia/echinodermata/echinodermata.html
+++ b/tree/animalia/echinodermata/echinodermata.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="echinodermata"></h2>
                     <picture>
-                        <source srcset="../../../images/thumbnails/webp_dir/Εχινόδερμα.webp 1x" type="image/webp">
+                        <source srcset="../../../images/thumbnails/webp_dir/%CE%95%CF%87%CE%B9%CE%BD%CF%8C%CE%B4%CE%B5%CF%81%CE%BC%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../images/thumbnails/Εχινόδερμα.jpg" alt="echinodermata" class="tax-page-image" id="echinodermata-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -38,7 +38,7 @@
                         <a href="echinoidea/echinoidea.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../images/thumbnails/thumbs_dir/Εχινοειδή_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../images/thumbnails/thumbs_dir/%CE%95%CF%87%CE%B9%CE%BD%CE%BF%CE%B5%CE%B9%CE%B4%CE%AE_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../images/thumbnails/thumbs_dir/Εχινοειδή_thumb.jpg" alt="echinoidea" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="echinodermata-echinoidea"></h3>

--- a/tree/animalia/echinodermata/echinoidea/echinoidea.html
+++ b/tree/animalia/echinodermata/echinoidea/echinoidea.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="echinoidea"></h2>
                     <picture>
-                        <source srcset="../../../../images/thumbnails/webp_dir/Εχινοειδή.webp 1x" type="image/webp">
+                        <source srcset="../../../../images/thumbnails/webp_dir/%CE%95%CF%87%CE%B9%CE%BD%CE%BF%CE%B5%CE%B9%CE%B4%CE%AE.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../images/thumbnails/Εχινοειδή.jpg" alt="echinoidea" class="tax-page-image" id="echinoidea-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -38,7 +38,7 @@
                         <a href="euechinoidea/euechinoidea.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../images/thumbnails/thumbs_dir/Ευεχινοειδή_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../images/thumbnails/thumbs_dir/%CE%95%CF%85%CE%B5%CF%87%CE%B9%CE%BD%CE%BF%CE%B5%CE%B9%CE%B4%CE%AE_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../images/thumbnails/thumbs_dir/Ευεχινοειδή_thumb.jpg" alt="euechinoidea" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="echinoidea-euechinoidea"></h3>

--- a/tree/animalia/echinodermata/echinoidea/euechinoidea/euechinoidea.html
+++ b/tree/animalia/echinodermata/echinoidea/euechinoidea/euechinoidea.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="euechinoidea"></h2>
                     <picture>
-                        <source srcset="../../../../../images/thumbnails/webp_dir/Ευεχινοειδή.webp 1x" type="image/webp">
+                        <source srcset="../../../../../images/thumbnails/webp_dir/%CE%95%CF%85%CE%B5%CF%87%CE%B9%CE%BD%CE%BF%CE%B5%CE%B9%CE%B4%CE%AE.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../images/thumbnails/Ευεχινοειδή.jpg" alt="euechinoidea" class="tax-page-image" id="euechinoidea-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -38,7 +38,7 @@
                         <a href="spatangoida/spatangoida.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/Σπαταγγοειδή_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/%CE%A3%CF%80%CE%B1%CF%84%CE%B1%CE%B3%CE%B3%CE%BF%CE%B5%CE%B9%CE%B4%CE%AE_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../images/thumbnails/thumbs_dir/Σπαταγγοειδή_thumb.jpg" alt="spatangoida" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="euechinoidea-spatangoida"></h3>

--- a/tree/animalia/echinodermata/echinoidea/euechinoidea/spatangoida/heterobrissus/heterobrissus.html
+++ b/tree/animalia/echinodermata/echinoidea/euechinoidea/spatangoida/heterobrissus/heterobrissus.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="heterobrissus"></h2>
                     <picture>
-                        <source srcset="../../../../../../../images/thumbnails/webp_dir/Ετεροβρίσσος.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../images/thumbnails/webp_dir/%CE%95%CF%84%CE%B5%CF%81%CE%BF%CE%B2%CF%81%CE%AF%CF%83%CF%83%CE%BF%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../images/thumbnails/Ετεροβρίσσος.jpg" alt="heterobrissus" class="tax-page-image" id="heterobrissus-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="heterobrissus_montesi/heterobrissus_montesi.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../../images/thumbnails/thumbs_dir/Ετεροβρίσσος ο μοντέσιος_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../../images/thumbnails/thumbs_dir/%CE%95%CF%84%CE%B5%CF%81%CE%BF%CE%B2%CF%81%CE%AF%CF%83%CF%83%CE%BF%CF%82%20%CE%BF%20%CE%BC%CE%BF%CE%BD%CF%84%CE%AD%CF%83%CE%B9%CE%BF%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../../images/thumbnails/thumbs_dir/Ετεροβρίσσος ο μοντέσιος_thumb.jpg" alt="heterobrissus montesi" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="heterobrissus-heterobrissus_montesi"></h3>

--- a/tree/animalia/echinodermata/echinoidea/euechinoidea/spatangoida/heterobrissus/heterobrissus_montesi/heterobrissus_montesi.html
+++ b/tree/animalia/echinodermata/echinoidea/euechinoidea/spatangoida/heterobrissus/heterobrissus_montesi/heterobrissus_montesi.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="heterobrissus_montesi"></h2>
                     <picture>
-                        <source srcset="../../../../../../../../images/thumbnails/webp_dir/Ετεροβρίσσος ο μοντέσιος.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../../images/thumbnails/webp_dir/%CE%95%CF%84%CE%B5%CF%81%CE%BF%CE%B2%CF%81%CE%AF%CF%83%CF%83%CE%BF%CF%82%20%CE%BF%20%CE%BC%CE%BF%CE%BD%CF%84%CE%AD%CF%83%CE%B9%CE%BF%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../../images/thumbnails/Ετεροβρίσσος ο μοντέσιος.jpg" alt="heterobrissus montesi" class="tax-page-image" id="heterobrissus_montesi-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/tree/animalia/echinodermata/echinoidea/euechinoidea/spatangoida/spatangoida.html
+++ b/tree/animalia/echinodermata/echinoidea/euechinoidea/spatangoida/spatangoida.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="spatangoida"></h2>
                     <picture>
-                        <source srcset="../../../../../../images/thumbnails/webp_dir/Σπαταγγοειδή.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../images/thumbnails/webp_dir/%CE%A3%CF%80%CE%B1%CF%84%CE%B1%CE%B3%CE%B3%CE%BF%CE%B5%CE%B9%CE%B4%CE%AE.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../images/thumbnails/Σπαταγγοειδή.jpg" alt="spatangoida" class="tax-page-image" id="spatangoida-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -38,7 +38,7 @@
                         <a href="heterobrissus/heterobrissus.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/Ετεροβρίσσος_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/%CE%95%CF%84%CE%B5%CF%81%CE%BF%CE%B2%CF%81%CE%AF%CF%83%CF%83%CE%BF%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../images/thumbnails/thumbs_dir/Ετεροβρίσσος_thumb.jpg" alt="heterobrissus" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="spatangoida-heterobrissus"></h3>

--- a/tree/animalia/mollusca/bivalvia/autobranchia/autobranchia.html
+++ b/tree/animalia/mollusca/bivalvia/autobranchia/autobranchia.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="autobranchia"></h2>
                     <picture>
-                        <source srcset="../../../../../images/thumbnails/webp_dir/Αυτοβράγχια.webp 1x" type="image/webp">
+                        <source srcset="../../../../../images/thumbnails/webp_dir/%CE%91%CF%85%CF%84%CE%BF%CE%B2%CF%81%CE%AC%CE%B3%CF%87%CE%B9%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../images/thumbnails/Αυτοβράγχια.jpg" alt="autobranchia" class="tax-page-image" id="autobranchia-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -71,7 +71,7 @@
                         <a href="ostreida/ostreida.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/Οστρείδια_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/%CE%9F%CF%83%CF%84%CF%81%CE%B5%CE%AF%CE%B4%CE%B9%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../images/thumbnails/thumbs_dir/Οστρείδια_thumb.jpg" alt="ostreida" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="autobranchia-ostreida"></h3>
@@ -80,7 +80,7 @@
                         <a href="veneridae/veneridae.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/Βενερίδες_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/%CE%92%CE%B5%CE%BD%CE%B5%CF%81%CE%AF%CE%B4%CE%B5%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../images/thumbnails/thumbs_dir/Βενερίδες_thumb.jpg" alt="veneridae" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="autobranchia-veneridae"></h3>

--- a/tree/animalia/mollusca/bivalvia/autobranchia/ostreida/gryphaea/gryphaea.html
+++ b/tree/animalia/mollusca/bivalvia/autobranchia/ostreida/gryphaea/gryphaea.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="gryphaea"></h2>
                     <picture>
-                        <source srcset="../../../../../../../images/thumbnails/webp_dir/Γρυφαία.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../images/thumbnails/webp_dir/%CE%93%CF%81%CF%85%CF%86%CE%B1%CE%AF%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../images/thumbnails/Γρυφαία.jpg" alt="gryphaea" class="tax-page-image" id="gryphaea-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/tree/animalia/mollusca/bivalvia/autobranchia/ostreida/ostreida.html
+++ b/tree/animalia/mollusca/bivalvia/autobranchia/ostreida/ostreida.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="ostreida"></h2>
                     <picture>
-                        <source srcset="../../../../../../images/thumbnails/webp_dir/Οστρείδια.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../images/thumbnails/webp_dir/%CE%9F%CF%83%CF%84%CF%81%CE%B5%CE%AF%CE%B4%CE%B9%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../images/thumbnails/Οστρείδια.jpg" alt="ostreida" class="tax-page-image" id="ostreida-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -82,7 +82,7 @@
                         <a href="gryphaea/gryphaea.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/Γρυφαία_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/%CE%93%CF%81%CF%85%CF%86%CE%B1%CE%AF%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../images/thumbnails/thumbs_dir/Γρυφαία_thumb.jpg" alt="gryphaea" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="ostreida-gryphaea"></h3>

--- a/tree/animalia/mollusca/bivalvia/autobranchia/veneridae/veneridae.html
+++ b/tree/animalia/mollusca/bivalvia/autobranchia/veneridae/veneridae.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="veneridae"></h2>
                     <picture>
-                        <source srcset="../../../../../../images/thumbnails/webp_dir/Βενερίδες.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../images/thumbnails/webp_dir/%CE%92%CE%B5%CE%BD%CE%B5%CF%81%CE%AF%CE%B4%CE%B5%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../images/thumbnails/Βενερίδες.jpg" alt="veneridae" class="tax-page-image" id="veneridae-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="venus/venus.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/Βένος_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/%CE%92%CE%AD%CE%BD%CE%BF%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../images/thumbnails/thumbs_dir/Βένος_thumb.jpg" alt="venus" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="veneridae-venus"></h3>

--- a/tree/animalia/mollusca/bivalvia/autobranchia/veneridae/venus/venus.html
+++ b/tree/animalia/mollusca/bivalvia/autobranchia/veneridae/venus/venus.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="venus"></h2>
                     <picture>
-                        <source srcset="../../../../../../../images/thumbnails/webp_dir/Βένος.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../images/thumbnails/webp_dir/%CE%92%CE%AD%CE%BD%CE%BF%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../images/thumbnails/Βένος.jpg" alt="venus" class="tax-page-image" id="venus-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/tree/animalia/mollusca/bivalvia/bivalvia.html
+++ b/tree/animalia/mollusca/bivalvia/bivalvia.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="bivalvia"></h2>
                     <picture>
-                        <source srcset="../../../../images/thumbnails/webp_dir/Δίθυρα.webp 1x" type="image/webp">
+                        <source srcset="../../../../images/thumbnails/webp_dir/%CE%94%CE%AF%CE%B8%CF%85%CF%81%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../images/thumbnails/Δίθυρα.jpg" alt="bivalvia" class="tax-page-image" id="bivalvia-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -201,7 +201,7 @@
                         <a href="autobranchia/autobranchia.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../images/thumbnails/thumbs_dir/Αυτοβράγχια_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../images/thumbnails/thumbs_dir/%CE%91%CF%85%CF%84%CE%BF%CE%B2%CF%81%CE%AC%CE%B3%CF%87%CE%B9%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../images/thumbnails/thumbs_dir/Αυτοβράγχια_thumb.jpg" alt="autobranchia" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="bivalvia-autobranchia"></h3>

--- a/tree/animalia/mollusca/cephalopoda/cephalopoda.html
+++ b/tree/animalia/mollusca/cephalopoda/cephalopoda.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="cephalopoda"></h2>
                     <picture>
-                        <source srcset="../../../../images/thumbnails/webp_dir/Κεφαλόποδα.webp 1x" type="image/webp">
+                        <source srcset="../../../../images/thumbnails/webp_dir/%CE%9A%CE%B5%CF%86%CE%B1%CE%BB%CF%8C%CF%80%CE%BF%CE%B4%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../images/thumbnails/Κεφαλόποδα.jpg" alt="cephalopoda" class="tax-page-image" id="cephalopoda-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="orthoceratoidea/orthoceratoidea.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../images/thumbnails/thumbs_dir/Ορθοκερατοειδή_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../images/thumbnails/thumbs_dir/%CE%9F%CF%81%CE%B8%CE%BF%CE%BA%CE%B5%CF%81%CE%B1%CF%84%CE%BF%CE%B5%CE%B9%CE%B4%CE%AE_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../images/thumbnails/thumbs_dir/Ορθοκερατοειδή_thumb.jpg" alt="orthoceratoidea" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="cephalopoda-orthoceratoidea"></h3>

--- a/tree/animalia/mollusca/cephalopoda/orthoceratoidea/coleoidea/argonautidae/argonautidae.html
+++ b/tree/animalia/mollusca/cephalopoda/orthoceratoidea/coleoidea/argonautidae/argonautidae.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="argonautidae"></h2>
                     <picture>
-                        <source srcset="../../../../../../../images/thumbnails/webp_dir/Αργοναυτίδες.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../images/thumbnails/webp_dir/%CE%91%CF%81%CE%B3%CE%BF%CE%BD%CE%B1%CF%85%CF%84%CE%AF%CE%B4%CE%B5%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../images/thumbnails/Αργοναυτίδες.jpg" alt="argonautidae" class="tax-page-image" id="argonautidae-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/tree/animalia/mollusca/cephalopoda/orthoceratoidea/coleoidea/coleoidea.html
+++ b/tree/animalia/mollusca/cephalopoda/orthoceratoidea/coleoidea/coleoidea.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="coleoidea"></h2>
                     <picture>
-                        <source srcset="../../../../../../images/thumbnails/webp_dir/Κολεοειδή.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../images/thumbnails/webp_dir/%CE%9A%CE%BF%CE%BB%CE%B5%CE%BF%CE%B5%CE%B9%CE%B4%CE%AE.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../images/thumbnails/Κολεοειδή.jpg" alt="coleoidea" class="tax-page-image" id="coleoidea-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="argonautidae/argonautidae.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/Αργοναυτίδες_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/%CE%91%CF%81%CE%B3%CE%BF%CE%BD%CE%B1%CF%85%CF%84%CE%AF%CE%B4%CE%B5%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../images/thumbnails/thumbs_dir/Αργοναυτίδες_thumb.jpg" alt="argonautidae" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="coleoidea-argonautidae"></h3>

--- a/tree/animalia/mollusca/cephalopoda/orthoceratoidea/orthoceratoidea.html
+++ b/tree/animalia/mollusca/cephalopoda/orthoceratoidea/orthoceratoidea.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="orthoceratoidea"></h2>
                     <picture>
-                        <source srcset="../../../../../images/thumbnails/webp_dir/Ορθοκερατοειδή.webp 1x" type="image/webp">
+                        <source srcset="../../../../../images/thumbnails/webp_dir/%CE%9F%CF%81%CE%B8%CE%BF%CE%BA%CE%B5%CF%81%CE%B1%CF%84%CE%BF%CE%B5%CE%B9%CE%B4%CE%AE.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../images/thumbnails/Ορθοκερατοειδή.jpg" alt="orthoceratoidea" class="tax-page-image" id="orthoceratoidea-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -181,7 +181,7 @@
                         <a href="coleoidea/coleoidea.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/Κολεοειδή_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/%CE%9A%CE%BF%CE%BB%CE%B5%CE%BF%CE%B5%CE%B9%CE%B4%CE%AE_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../images/thumbnails/thumbs_dir/Κολεοειδή_thumb.jpg" alt="coleoidea" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="orthoceratoidea-coleoidea"></h3>

--- a/tree/animalia/mollusca/gastropoda/caenogastropoda/caenogastropoda.html
+++ b/tree/animalia/mollusca/gastropoda/caenogastropoda/caenogastropoda.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="caenogastropoda"></h2>
                     <picture>
-                        <source srcset="../../../../../images/thumbnails/webp_dir/Καινογαστρόποδα.webp 1x" type="image/webp">
+                        <source srcset="../../../../../images/thumbnails/webp_dir/%CE%9A%CE%B1%CE%B9%CE%BD%CE%BF%CE%B3%CE%B1%CF%83%CF%84%CF%81%CF%8C%CF%80%CE%BF%CE%B4%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../images/thumbnails/Καινογαστρόποδα.jpg" alt="caenogastropoda" class="tax-page-image" id="caenogastropoda-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="turritellidae/turritellidae.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/Τουρριτελλίδες_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/%CE%A4%CE%BF%CF%85%CF%81%CF%81%CE%B9%CF%84%CE%B5%CE%BB%CE%BB%CE%AF%CE%B4%CE%B5%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../images/thumbnails/thumbs_dir/Τουρριτελλίδες_thumb.jpg" alt="turritellidae" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="caenogastropoda-turritellidae"></h3>

--- a/tree/animalia/mollusca/gastropoda/caenogastropoda/turritellidae/turritellidae.html
+++ b/tree/animalia/mollusca/gastropoda/caenogastropoda/turritellidae/turritellidae.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="turritellidae"></h2>
                     <picture>
-                        <source srcset="../../../../../../images/thumbnails/webp_dir/Τουρριτελλίδες.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../images/thumbnails/webp_dir/%CE%A4%CE%BF%CF%85%CF%81%CF%81%CE%B9%CF%84%CE%B5%CE%BB%CE%BB%CE%AF%CE%B4%CE%B5%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../images/thumbnails/Τουρριτελλίδες.jpg" alt="turritellidae" class="tax-page-image" id="turritellidae-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/tree/animalia/mollusca/gastropoda/gastropoda.html
+++ b/tree/animalia/mollusca/gastropoda/gastropoda.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="gastropoda"></h2>
                     <picture>
-                        <source srcset="../../../../images/thumbnails/webp_dir/Γαστρόποδα.webp 1x" type="image/webp">
+                        <source srcset="../../../../images/thumbnails/webp_dir/%CE%93%CE%B1%CF%83%CF%84%CF%81%CF%8C%CF%80%CE%BF%CE%B4%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../images/thumbnails/Γαστρόποδα.jpg" alt="gastropoda" class="tax-page-image" id="gastropoda-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -82,7 +82,7 @@
                         <a href="neritimorpha/neritimorpha.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../images/thumbnails/thumbs_dir/Νηριτίμορφα_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../images/thumbnails/thumbs_dir/%CE%9D%CE%B7%CF%81%CE%B9%CF%84%CE%AF%CE%BC%CE%BF%CF%81%CF%86%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../images/thumbnails/thumbs_dir/Νηριτίμορφα_thumb.jpg" alt="neritimorpha" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="gastropoda-neritimorpha"></h3>
@@ -91,7 +91,7 @@
                         <a href="caenogastropoda/caenogastropoda.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../images/thumbnails/thumbs_dir/Καινογαστρόποδα_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../images/thumbnails/thumbs_dir/%CE%9A%CE%B1%CE%B9%CE%BD%CE%BF%CE%B3%CE%B1%CF%83%CF%84%CF%81%CF%8C%CF%80%CE%BF%CE%B4%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../images/thumbnails/thumbs_dir/Καινογαστρόποδα_thumb.jpg" alt="caenogastropoda" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="gastropoda-caenogastropoda"></h3>
@@ -100,7 +100,7 @@
                         <a href="heterobranchia/heterobranchia.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../images/thumbnails/thumbs_dir/Ετεροβράγχια_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../images/thumbnails/thumbs_dir/%CE%95%CF%84%CE%B5%CF%81%CE%BF%CE%B2%CF%81%CE%AC%CE%B3%CF%87%CE%B9%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../images/thumbnails/thumbs_dir/Ετεροβράγχια_thumb.jpg" alt="heterobranchia" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="gastropoda-heterobranchia"></h3>

--- a/tree/animalia/mollusca/gastropoda/heterobranchia/cavoliniidae/cavoliniidae.html
+++ b/tree/animalia/mollusca/gastropoda/heterobranchia/cavoliniidae/cavoliniidae.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="cavoliniidae"></h2>
                     <picture>
-                        <source srcset="../../../../../../images/thumbnails/webp_dir/Καβολινίδες.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../images/thumbnails/webp_dir/%CE%9A%CE%B1%CE%B2%CE%BF%CE%BB%CE%B9%CE%BD%CE%AF%CE%B4%CE%B5%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../images/thumbnails/Καβολινίδες.jpg" alt="cavoliniidae" class="tax-page-image" id="cavoliniidae-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="diacria/diacria.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/Διακρία_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/%CE%94%CE%B9%CE%B1%CE%BA%CF%81%CE%AF%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../images/thumbnails/thumbs_dir/Διακρία_thumb.jpg" alt="diacria" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="cavoliniidae-diacria"></h3>

--- a/tree/animalia/mollusca/gastropoda/heterobranchia/cavoliniidae/diacria/diacria.html
+++ b/tree/animalia/mollusca/gastropoda/heterobranchia/cavoliniidae/diacria/diacria.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="diacria"></h2>
                     <picture>
-                        <source srcset="../../../../../../../images/thumbnails/webp_dir/Διακρία.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../images/thumbnails/webp_dir/%CE%94%CE%B9%CE%B1%CE%BA%CF%81%CE%AF%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../images/thumbnails/Διακρία.jpg" alt="diacria" class="tax-page-image" id="diacria-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -38,7 +38,7 @@
                         <a href="diacria_trispinosa/diacria_trispinosa.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../../images/thumbnails/thumbs_dir/Διακρία η τριάκανθος_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../../images/thumbnails/thumbs_dir/%CE%94%CE%B9%CE%B1%CE%BA%CF%81%CE%AF%CE%B1%20%CE%B7%20%CF%84%CF%81%CE%B9%CE%AC%CE%BA%CE%B1%CE%BD%CE%B8%CE%BF%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../../images/thumbnails/thumbs_dir/Διακρία η τριάκανθος_thumb.jpg" alt="diacria trispinosa" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="diacria-diacria_trispinosa"></h3>

--- a/tree/animalia/mollusca/gastropoda/heterobranchia/cavoliniidae/diacria/diacria_trispinosa/diacria_trispinosa.html
+++ b/tree/animalia/mollusca/gastropoda/heterobranchia/cavoliniidae/diacria/diacria_trispinosa/diacria_trispinosa.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="diacria_trispinosa"></h2>
                     <picture>
-                        <source srcset="../../../../../../../../images/thumbnails/webp_dir/Διακρία η τριάκανθος.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../../images/thumbnails/webp_dir/%CE%94%CE%B9%CE%B1%CE%BA%CF%81%CE%AF%CE%B1%20%CE%B7%20%CF%84%CF%81%CE%B9%CE%AC%CE%BA%CE%B1%CE%BD%CE%B8%CE%BF%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../../images/thumbnails/Διακρία η τριάκανθος.jpg" alt="diacria trispinosa" class="tax-page-image" id="diacria_trispinosa-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/tree/animalia/mollusca/gastropoda/heterobranchia/heterobranchia.html
+++ b/tree/animalia/mollusca/gastropoda/heterobranchia/heterobranchia.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="heterobranchia"></h2>
                     <picture>
-                        <source srcset="../../../../../images/thumbnails/webp_dir/Ετεροβράγχια.webp 1x" type="image/webp">
+                        <source srcset="../../../../../images/thumbnails/webp_dir/%CE%95%CF%84%CE%B5%CF%81%CE%BF%CE%B2%CF%81%CE%AC%CE%B3%CF%87%CE%B9%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../images/thumbnails/Ετεροβράγχια.jpg" alt="heterobranchia" class="tax-page-image" id="heterobranchia-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="cavoliniidae/cavoliniidae.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/Καβολινίδες_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/%CE%9A%CE%B1%CE%B2%CE%BF%CE%BB%CE%B9%CE%BD%CE%AF%CE%B4%CE%B5%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../images/thumbnails/thumbs_dir/Καβολινίδες_thumb.jpg" alt="cavoliniidae" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="heterobranchia-cavoliniidae"></h3>

--- a/tree/animalia/mollusca/gastropoda/neritimorpha/neritidae/neritidae.html
+++ b/tree/animalia/mollusca/gastropoda/neritimorpha/neritidae/neritidae.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="neritidae"></h2>
                     <picture>
-                        <source srcset="../../../../../../images/thumbnails/webp_dir/Νηριτίδες.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../images/thumbnails/webp_dir/%CE%9D%CE%B7%CF%81%CE%B9%CF%84%CE%AF%CE%B4%CE%B5%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../images/thumbnails/Νηριτίδες.jpg" alt="neritidae" class="tax-page-image" id="neritidae-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="theodoxus/theodoxus.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/Θεόδοξος_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../images/thumbnails/thumbs_dir/%CE%98%CE%B5%CF%8C%CE%B4%CE%BF%CE%BE%CE%BF%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../images/thumbnails/thumbs_dir/Θεόδοξος_thumb.jpg" alt="theodoxus" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="neritidae-theodoxus"></h3>

--- a/tree/animalia/mollusca/gastropoda/neritimorpha/neritidae/theodoxus/theodoxus.html
+++ b/tree/animalia/mollusca/gastropoda/neritimorpha/neritidae/theodoxus/theodoxus.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="theodoxus"></h2>
                     <picture>
-                        <source srcset="../../../../../../../images/thumbnails/webp_dir/Θεόδοξος.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../images/thumbnails/webp_dir/%CE%98%CE%B5%CF%8C%CE%B4%CE%BF%CE%BE%CE%BF%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../images/thumbnails/Θεόδοξος.jpg" alt="theodoxus" class="tax-page-image" id="theodoxus-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="theodoxus_pisiformis/theodoxus_pisiformis.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../../../images/thumbnails/thumbs_dir/Θεόδοξος ο πισόμορφος_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../../../images/thumbnails/thumbs_dir/%CE%98%CE%B5%CF%8C%CE%B4%CE%BF%CE%BE%CE%BF%CF%82%20%CE%BF%20%CF%80%CE%B9%CF%83%CF%8C%CE%BC%CE%BF%CF%81%CF%86%CE%BF%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../../../images/thumbnails/thumbs_dir/Θεόδοξος ο πισόμορφος_thumb.jpg" alt="theodoxus pisiformis" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="theodoxus-theodoxus_pisiformis"></h3>

--- a/tree/animalia/mollusca/gastropoda/neritimorpha/neritidae/theodoxus/theodoxus_pisiformis/theodoxus_pisiformis.html
+++ b/tree/animalia/mollusca/gastropoda/neritimorpha/neritidae/theodoxus/theodoxus_pisiformis/theodoxus_pisiformis.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="theodoxus_pisiformis"></h2>
                     <picture>
-                        <source srcset="../../../../../../../../images/thumbnails/webp_dir/Θεόδοξος ο πισόμορφος.webp 1x" type="image/webp">
+                        <source srcset="../../../../../../../../images/thumbnails/webp_dir/%CE%98%CE%B5%CF%8C%CE%B4%CE%BF%CE%BE%CE%BF%CF%82%20%CE%BF%20%CF%80%CE%B9%CF%83%CF%8C%CE%BC%CE%BF%CF%81%CF%86%CE%BF%CF%82.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../../../../images/thumbnails/Θεόδοξος ο πισόμορφος.jpg" alt="theodoxus pisiformis" class="tax-page-image" id="theodoxus_pisiformis-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/tree/animalia/mollusca/gastropoda/neritimorpha/neritimorpha.html
+++ b/tree/animalia/mollusca/gastropoda/neritimorpha/neritimorpha.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="neritimorpha"></h2>
                     <picture>
-                        <source srcset="../../../../../images/thumbnails/webp_dir/Νηριτίμορφα.webp 1x" type="image/webp">
+                        <source srcset="../../../../../images/thumbnails/webp_dir/%CE%9D%CE%B7%CF%81%CE%B9%CF%84%CE%AF%CE%BC%CE%BF%CF%81%CF%86%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../../../images/thumbnails/Νηριτίμορφα.jpg" alt="neritimorpha" class="tax-page-image" id="neritimorpha-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="neritidae/neritidae.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/Νηριτίδες_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../../../images/thumbnails/thumbs_dir/%CE%9D%CE%B7%CF%81%CE%B9%CF%84%CE%AF%CE%B4%CE%B5%CF%82_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../../../images/thumbnails/thumbs_dir/Νηριτίδες_thumb.jpg" alt="neritidae" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="neritimorpha-neritidae"></h3>

--- a/tree/animalia/mollusca/mollusca.html
+++ b/tree/animalia/mollusca/mollusca.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="mollusca"></h2>
                     <picture>
-                        <source srcset="../../../images/thumbnails/webp_dir/Μαλάκια.webp 1x" type="image/webp">
+                        <source srcset="../../../images/thumbnails/webp_dir/%CE%9C%CE%B1%CE%BB%CE%AC%CE%BA%CE%B9%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../../images/thumbnails/Μαλάκια.jpg" alt="mollusca" class="tax-page-image" id="mollusca-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">
@@ -36,7 +36,7 @@
                         <a href="gastropoda/gastropoda.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../images/thumbnails/thumbs_dir/Γαστρόποδα_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../images/thumbnails/thumbs_dir/%CE%93%CE%B1%CF%83%CF%84%CF%81%CF%8C%CF%80%CE%BF%CE%B4%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../images/thumbnails/thumbs_dir/Γαστρόποδα_thumb.jpg" alt="gastropoda" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="mollusca-gastropoda"></h3>
@@ -45,7 +45,7 @@
                         <a href="bivalvia/bivalvia.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../images/thumbnails/thumbs_dir/Δίθυρα_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../images/thumbnails/thumbs_dir/%CE%94%CE%AF%CE%B8%CF%85%CF%81%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../images/thumbnails/thumbs_dir/Δίθυρα_thumb.jpg" alt="bivalvia" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="mollusca-bivalvia"></h3>
@@ -54,7 +54,7 @@
                         <a href="cephalopoda/cephalopoda.html">
                             <div class="tax-subcontainer">
                                 <picture>
-                                    <source srcset="../../../images/thumbnails/thumbs_dir/Κεφαλόποδα_thumb.webp 1x" type="image/webp">
+                                    <source srcset="../../../images/thumbnails/thumbs_dir/%CE%9A%CE%B5%CF%86%CE%B1%CE%BB%CF%8C%CF%80%CE%BF%CE%B4%CE%B1_thumb.webp 1x" type="image/webp">
                                     <img loading="lazy" src="../../../images/thumbnails/thumbs_dir/Κεφαλόποδα_thumb.jpg" alt="cephalopoda" class="tax-thumbnail-image">
                                 </picture>
                                 <h3 id="mollusca-cephalopoda"></h3>

--- a/tree/plantae/plantae.html
+++ b/tree/plantae/plantae.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="plantae"></h2>
                     <picture>
-                        <source srcset="../../images/thumbnails/webp_dir/Φυτά.webp 1x" type="image/webp">
+                        <source srcset="../../images/thumbnails/webp_dir/%CE%A6%CF%85%CF%84%CE%AC.webp 1x" type="image/webp">
                         <img loading="lazy" src="../../images/thumbnails/Φυτά.jpg" alt="plantae" class="tax-page-image" id="plantae-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">

--- a/unclassified.html
+++ b/unclassified.html
@@ -19,7 +19,7 @@
                 <div class="tax-subcontainer">
                     <h2 id="unclassified"></h2>
                     <picture>
-                        <source srcset="images/thumbnails/webp_dir/Ακατηγοριοποίητα.webp 1x" type="image/webp">
+                        <source srcset="images/thumbnails/webp_dir/%CE%91%CE%BA%CE%B1%CF%84%CE%B7%CE%B3%CE%BF%CF%81%CE%B9%CE%BF%CF%80%CE%BF%CE%AF%CE%B7%CF%84%CE%B1.webp 1x" type="image/webp">
                         <img loading="lazy" src="images/thumbnails/Ακατηγοριοποίητα.jpg" alt="unclassified" class="tax-page-image" id="unclassified-περιγραφή-1-εικόνα">
                     </picture>
                     <div class="description-text">


### PR DESCRIPTION
- Show samples in a grid, with a taxon thumbnail taking up the top-left 4 grid positions
- link to taxon pages
- changes in style.css
- added unclassified to dict.json
- updated .template files and generate_site.py