### PR TITLE
Refactor A: unify duplicated getLanguage()

### DIFF
--- a/scripts/header.js
+++ b/scripts/header.js
@@ -6,11 +6,6 @@ fetch(getBaseURL() + "/jsondata/pages.json").then((resp) => resp.json()).then((j
     pages = json["pages"];
 }).catch((err) => console.error(err));
 
-// ΧXX: stolen from language.js. need to update both functions for changes
-function getLanguage() {
-  return localStorage.getItem('language') || 'en'; // Προεπιλεγμένη γλώσσα τα Αγγλικά
-}
-
 function pageToKey(page) {
   return page.name.toLowerCase().replace(" ", "_")
 }

--- a/scripts/language.js
+++ b/scripts/language.js
@@ -71,10 +71,8 @@ function setLanguage(lang) {
   applyLanguage(lang);
 }
   
-// Function to get the language
-// ΧXX: copied in header.js. need to update both functions for changes
 function getLanguage() {
-  return localStorage.getItem('language') || 'en'; // Προεπιλεγμένη γλώσσα τα Αγγλικά
+  return localStorage.getItem('language') || 'en';
 }
 
 function constructTimeStr(age, lang) {


### PR DESCRIPTION
## Summary

- Removed the duplicated `getLanguage()` from `scripts/header.js` and the ransom-note comments instructing callers to "update both functions" (the one in `language.js` is the only definition that survives).
- `language.js` loads before `header.js` in every template that uses both (`map`, `taxon`, `locality`, `index` — verified by grep), so the function remains in scope where it was called.

## Test plan

- [x] `.venv/bin/python -m pyscripts.site_generator.generate_site` exits 0
- [ ] Manual: load homepage in three languages, confirm `getLanguage()` is still picked up from header.js's call-sites without a `ReferenceError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)