### PR TITLE
Refactor B: use attribute selector for locality elements

### DIFF
--- a/scripts/language.js
+++ b/scripts/language.js
@@ -256,12 +256,7 @@ function applyLanguage(lang) {
       }
 
       // Τοποθεσίες δειγμάτων
-      const allElems = doc.querySelectorAll('*');
-      allElems.forEach((elem) => {
-        if (!elem.id || !elem.id.startsWith('locality-')) {
-          return;
-        }
-        const locality = elem;
+      doc.querySelectorAll('[id^="locality-"]').forEach((locality) => {
         const localityId = locality.id.replace('locality-', '');
         constructLocalityStr(localityId, lang).then((locality_str) => {
           locality.innerText = locality_str;


### PR DESCRIPTION
## Summary

- In `scripts/language.js`, replaced the full-DOM `document.querySelectorAll('*')` walk used to find `id^="locality-"` elements with a direct `[id^="locality-"]` selector.
- Same behavior; no full-DOM traversal on every `applyLanguage` call.

## Test plan

- [x] `.venv/bin/python -m pyscripts.site_generator.generate_site` exits 0
- [ ] Manual: load a locality-bearing sample page (e.g. taxon page where the gallery captions include a locality), switch languages, confirm locality strings still render in all three languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)