### PR TITLE
Refactor C: move stapled DOM properties to dataset

### DIFF
--- a/pyscripts/site_generator/templates/random-sample.js.template
+++ b/pyscripts/site_generator/templates/random-sample.js.template
@@ -47,8 +47,8 @@ let species = sample.species;
 if(Array.isArray(species)) {
     species = species[Math.floor(Math.random() * species.length)];
 }
-title.unprocessed_title = species;
-title.extinct = taxon_extinct(species)
+title.dataset.unprocessedTitle = species;
+if (taxon_extinct(species)) title.dataset.extinct = '1';
 // Set the image link
 var link = doc.getElementById('τυχαίο-δείγμα-σύνδεσμος');
 link.href = getBaseURL() + taxon_to_link(species);

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -91,8 +91,8 @@ async function loadTaxonomyTree(taxData, samples) {
       a.href = `${taxonPath}/${key}/${key}.html`;
       a.id = `tree-node-${key}`;
       a.className = "tree-node";
-      a.count = count;
-      a.extinct = value.extinct || false;
+      a.dataset.sampleCount = count;
+      if (value.extinct) a.dataset.extinct = '1';
 
       const label = (value.name?.en || key) + (count ? ` (${count})` : "");
       a.textContent = label;
@@ -283,8 +283,8 @@ fetch(getBaseURL() + '/templates/header.html')
                 navpath.style.display = "none";
             }
         } else {
-          pathElement.path = getPath();
-          if(pathElement.path.length > 0) {
+          navPath = getPath();
+          if(navPath.length > 0) {
             pathElement.style.display = "flex";
           }
         }

--- a/scripts/language.js
+++ b/scripts/language.js
@@ -39,6 +39,7 @@ const getRelativePath = (absolutePath) => {
 //language.js
 var doc = document;
 let navPathLoaded = false;
+let navPath = null;
 let globalDict = {};
 let globalDictLoaded = false;
 
@@ -179,8 +180,8 @@ function applyLanguage(lang) {
 
         const pathElement = document.getElementById('navpath');
         pathElement.innerHTML = "";
-        if (pathElement.path) {
-          pathElement.path.forEach((item, index) => {
+        if (navPath) {
+          navPath.forEach((item, index) => {
             const translated = globalDict[lang][item.name];
             console.assert(translated, `Missing translation for ${item.name} in language '${lang}'.`)
             if(index != 0) {
@@ -203,10 +204,11 @@ function applyLanguage(lang) {
                 const translation = globalDict[lang][id];
                 console.assert(translation, `Missing translation for ${id} in language '${lang}'.`);
                 link.textContent = globalDict[lang][id];
-                if (link.count > 0) {
-                  link.textContent += ` (${link.count}🦴)`;
+                const count = Number(link.dataset.sampleCount || 0);
+                if (count > 0) {
+                  link.textContent += ` (${count}🦴)`;
                 }
-                if (link.extinct) {
+                if (link.dataset.extinct === '1') {
                   link.textContent = "†" + link.textContent;
                 }
                 if(root.ul) {
@@ -245,11 +247,11 @@ function applyLanguage(lang) {
 
       // Τυχαίο δείγμα
       const randomSampleTitleElement = document.getElementById('τυχαίο-δείγμα-τίτλος');
-      if (randomSampleTitleElement && "unprocessed_title" in randomSampleTitleElement) {
-        let randomTitle = randomSampleTitleElement.unprocessed_title;
+      if (randomSampleTitleElement && randomSampleTitleElement.dataset.unprocessedTitle) {
+        const randomTitle = randomSampleTitleElement.dataset.unprocessedTitle;
         console.assert(randomTitle in globalDict[lang], `Missing translation for ${randomTitle} in ${lang}`);
         randomSampleTitleElement.textContent = "";
-        if(randomSampleTitleElement.extinct) {
+        if(randomSampleTitleElement.dataset.extinct === '1') {
           randomSampleTitleElement.textContent = "†";
         }
         randomSampleTitleElement.textContent += globalDict[lang][randomTitle];

--- a/scripts/random-sample.js
+++ b/scripts/random-sample.js
@@ -3017,8 +3017,8 @@ let species = sample.species;
 if(Array.isArray(species)) {
     species = species[Math.floor(Math.random() * species.length)];
 }
-title.unprocessed_title = species;
-title.extinct = taxon_extinct(species)
+title.dataset.unprocessedTitle = species;
+if (taxon_extinct(species)) title.dataset.extinct = '1';
 // Set the image link
 var link = doc.getElementById('τυχαίο-δείγμα-σύνδεσμος');
 link.href = getBaseURL() + taxon_to_link(species);


### PR DESCRIPTION
## Summary

State previously stapled onto DOM elements as custom JS properties is moved into standard `dataset` attributes (or, for the navigation path, a module-level variable shared between `header.js` and `language.js`).

- `scripts/header.js`: taxonomy tree links now write `dataset.sampleCount` and `dataset.extinct`; navigation path is assigned to a shared `navPath` variable in `language.js` instead of `pathElement.path`.
- `scripts/language.js`: declares `navPath`; reads `dataset.sampleCount`, `dataset.extinct`, `dataset.unprocessedTitle`.
- `pyscripts/site_generator/templates/random-sample.js.template`: writes `dataset.unprocessedTitle` and `dataset.extinct` on the random-sample title element.
- `scripts/random-sample.js` regenerated.

## Test plan

- [x] `.venv/bin/python -m pyscripts.site_generator.generate_site` exits 0
- [x] Homepage: random sample title still shows the localised species name and the `†` prefix for extinct taxa, in all three languages.
- [x] Any taxon page: sidebar tree still shows `(N🦴)` counts and `†` prefixes after switching language.
- [x] Any taxon-tree page: breadcrumbs still render after switching language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)