### PR TITLE
Refactor D: split applyLanguage() into per-section update functions

### DIFF
--- a/scripts/language.js
+++ b/scripts/language.js
@@ -115,171 +115,179 @@ function constructLocalityStr(localityId, lang) {
   });
 }
   
-// Function to apply the selected language to the page
-function applyLanguage(lang) {
-  // update dropdown default view
+function updateLanguageDropdown(lang) {
   const lang_toggle = document.getElementById("language-toggle");
-  if(lang_toggle !== null) {
+  if (lang_toggle !== null) {
     lang_toggle.innerHTML = `<img src="${getBaseURL() + "/images/flags/" + languages_dict[lang].thumb}" width="20" alt="${languages_dict[lang].alt}"> ${languages_dict[lang].text} ▼`;
   }
+}
+
+function updatePageKeys(lang, translations, keys) {
+  if (keys === "") return;
+  keys.forEach(key => {
+    const elem = doc.getElementById(key);
+    if (!elem) {
+      console.error("Missing element \"" + key + "\" from page");
+      return;
+    }
+    if (key in translations[lang]) {
+      elem.textContent = translations[lang][key];
+    } else if (key in globalDict[lang]) {
+      elem.textContent = globalDict[lang][key];
+    } else {
+      console.error("Missing translation for \"" + key + "\" in language '" + lang + "'");
+    }
+    if (elem.parentElement.classList.contains("description-text")) {
+      // Ειδική περίπτωση για μεγάλες περιγραφές: μόνο το ένα από τα στοιχεία ενεργοποιεί την εικόνα
+      if (key.endsWith("-περιγραφή-1")) {
+        const page_image = doc.getElementById(key + "-εικόνα");
+        page_image.style.display = "block";
+        page_image.style.visibility = "visible";
+      }
+    }
+  });
+}
+
+function updateGalleryCaptions(lang, translations, galleryLength) {
+  if (galleryLength <= 0) return;
+  for (let i = 1; i <= galleryLength; i++) {
+    const item = doc.getElementById('gallery-img-' + i);
+    item.setAttribute('data-sub-html', translations[lang]['gallery'][i - 1]);
+  }
+}
+
+function updateHeaderNav(lang) {
+  document.getElementById('home-btn').innerHTML = globalDict[lang]['home'];
+  document.getElementById('map-btn').innerHTML = globalDict[lang]['map'];
+  document.getElementById('journal-btn').innerHTML = globalDict[lang]['journal'];
+
+  const pathElement = document.getElementById('navpath');
+  pathElement.innerHTML = "";
+  if (!navPath) return;
+  navPath.forEach((item, index) => {
+    const translated = globalDict[lang][item.name];
+    console.assert(translated, `Missing translation for ${item.name} in language '${lang}'.`);
+    if (index != 0) {
+      pathElement.innerHTML += "<span>/</span>";
+    }
+    pathElement.innerHTML = pathElement.innerHTML + `<a href="${item.link}">${translated}</a>`;
+  });
+}
+
+function updateSidebarTree(lang) {
+  waitForCondition(
+    () => document.getElementById('sidebar'),
+    () => {
+      const sidebar = document.getElementById('sidebar');
+      const traverse_fun = (root) => {
+        if (!root) return;
+        root.querySelectorAll('li').forEach((sidebarItem) => {
+          const link = sidebarItem.querySelector('a');
+          // link id is in the form of "tree-node-<id>"
+          const id = link.id.replace('tree-node-', '');
+          const translation = globalDict[lang][id];
+          console.assert(translation, `Missing translation for ${id} in language '${lang}'.`);
+          link.textContent = globalDict[lang][id];
+          const count = Number(link.dataset.sampleCount || 0);
+          if (count > 0) {
+            link.textContent += ` (${count}🦴)`;
+          }
+          if (link.dataset.extinct === '1') {
+            link.textContent = "†" + link.textContent;
+          }
+          if (root.ul) {
+            traverse_fun(root.querySelector('ul'));
+          }
+        });
+      };
+      traverse_fun(sidebar.querySelector('div[id="tree-container"]').querySelector('ul'));
+      sidebar.style.display = "block";
+    }
+  );
+}
+
+function updateSearchPlaceholder(lang) {
+  const searchInput = document.getElementById('search-input');
+  if (searchInput) {
+    searchInput.placeholder = globalDict[lang]['search-placeholder'];
+  }
+}
+
+function updateFooter(lang) {
+  const footer_elements = ["footer-name", "footer-source"];
+  waitForCondition(
+    () => document.getElementById(footer_elements[0]),
+    () => {
+      for (const elem_id of footer_elements) {
+        if (elem_id in globalDict[lang]) {
+          document.getElementById(elem_id).innerText = globalDict[lang][elem_id];
+        } else {
+          console.error(`Missing translation for ${elem_id} in language '${lang}'.`);
+        }
+      }
+    }
+  );
+}
+
+function updateRandomSampleTitle(lang) {
+  const titleElem = document.getElementById('τυχαίο-δείγμα-τίτλος');
+  if (!titleElem || !titleElem.dataset.unprocessedTitle) return;
+  const randomTitle = titleElem.dataset.unprocessedTitle;
+  console.assert(randomTitle in globalDict[lang], `Missing translation for ${randomTitle} in ${lang}`);
+  titleElem.textContent = titleElem.dataset.extinct === '1' ? "†" : "";
+  titleElem.textContent += globalDict[lang][randomTitle];
+}
+
+function updateLocalityStrings(lang) {
+  doc.querySelectorAll('[id^="locality-"]').forEach((locality) => {
+    const localityId = locality.id.replace('locality-', '');
+    constructLocalityStr(localityId, lang).then((locality_str) => {
+      locality.innerText = locality_str;
+    });
+  });
+}
+
+function updateCookieBanner(lang) {
+  const cookieBanner = doc.getElementById('cookie-banner');
+  if (!cookieBanner) return;
+  const subelements = ["cookie-banner-text", "cookie-banner-accept", "cookie-banner-decline"];
+  subelements.forEach((subelem) => {
+    const elem = doc.getElementById(subelem);
+    if (!elem) {
+      console.error(`Missing element with id ${subelem}`);
+      return;
+    }
+    console.assert(subelem in globalDict[lang], `Missing translation for ${subelem} in language '${lang}'.`);
+    elem.textContent = globalDict[lang][subelem];
+  });
+}
+
+function applyLanguage(lang) {
+  updateLanguageDropdown(lang);
 
   const thisScript = document.getElementById('language-script');
-  dictPath = thisScript.getAttribute('dict');
-  keys = thisScript.getAttribute('keys');
-  if(keys !== "") {
+  const dictPath = thisScript.getAttribute('dict');
+  let keys = thisScript.getAttribute('keys');
+  if (keys !== "") {
     keys = keys.split(',');
   }
-  galleryLength = Number(thisScript.getAttribute('galleryLength'));
+  const galleryLength = Number(thisScript.getAttribute('galleryLength'));
+
   fetch(getBaseURL() + dictPath)
-  .then(response => response.json())
-  .then(translations => {
-    if(keys !== "") {
-      keys.forEach(key => {
-          const elem = doc.getElementById(key);
-          if (elem) {
-            if (key in translations[lang]) {
-              elem.textContent = translations[lang][key];
-            } else if (key in globalDict[lang]) {
-              elem.textContent = globalDict[lang][key];
-            } else {
-              console.error("Missing translation for \"" + key + "\" in language '" + lang + "'");
-            }
-            if (elem.parentElement.classList.contains("description-text")) {
-              // Ειδική περίπτωση για μεγάλες περιγραφές
-              // θέλουμε μόνο το ένα από τα στοιχεία να ενεργοποιεί
-              if (key.endsWith("-περιγραφή-1")) {
-                const page_image = doc.getElementById(key + "-εικόνα");
-                // Ειδική περίπτωση για την εικόνα της σελίδας, της οποίας το μέγεθος εξαρτάται από το μέγεθος της παραγράφου
-                page_image.style.display = "block";
-                page_image.style.visibility = "visible";
-              }
-            }
-          } else {
-            console.error("Missing element \"" + key + "\" from page")
-          }
-      });
-    }
-
-    // Ειδική περίπτωση για την γκαλερί
-    if (galleryLength > 0) {
-        for (let i = 1; i <= galleryLength; i++) {
-            item = doc.getElementById('gallery-img-' + i);
-            const translatedCaption = translations[lang]['gallery'][i-1];
-            item.setAttribute('data-sub-html', translatedCaption);
-        }
-    }
-
-    // Ειδική περίπτωση για την κεφαλίδα (πλήκτρα πλοήγησης) + sidebar
+    .then(response => response.json())
+    .then(translations => {
+      updatePageKeys(lang, translations, keys);
+      updateGalleryCaptions(lang, translations, galleryLength);
       if (navPathLoaded && globalDictLoaded) {
-        const homeBtn = document.getElementById('home-btn');
-        homeBtn.innerHTML = globalDict[lang]['home']
-        const mapBtn = document.getElementById('map-btn');
-        mapBtn.innerHTML = globalDict[lang]['map']
-        const journalBtn = document.getElementById('journal-btn');
-        journalBtn.innerHTML = globalDict[lang]['journal']
-
-        const pathElement = document.getElementById('navpath');
-        pathElement.innerHTML = "";
-        if (navPath) {
-          navPath.forEach((item, index) => {
-            const translated = globalDict[lang][item.name];
-            console.assert(translated, `Missing translation for ${item.name} in language '${lang}'.`)
-            if(index != 0) {
-              pathElement.innerHTML += "<span>/</span>"
-            }
-            pathElement.innerHTML = pathElement.innerHTML + `<a href="${item.link}">${translated}</a>`;
-          });
-        }
-        waitForCondition(
-          () => document.getElementById('sidebar'),
-          () => {
-            const sidebar = document.getElementById('sidebar');
-            const traverse_fun = (root) => {
-              if(!root) return;
-              // for each li child of root
-              root.querySelectorAll('li').forEach((sidebarItem) => {
-                const link = sidebarItem.querySelector('a');
-                // link id is in the form of "tree-node-<id>"
-                const id = link.id.replace('tree-node-', '');
-                const translation = globalDict[lang][id];
-                console.assert(translation, `Missing translation for ${id} in language '${lang}'.`);
-                link.textContent = globalDict[lang][id];
-                const count = Number(link.dataset.sampleCount || 0);
-                if (count > 0) {
-                  link.textContent += ` (${count}🦴)`;
-                }
-                if (link.dataset.extinct === '1') {
-                  link.textContent = "†" + link.textContent;
-                }
-                if(root.ul) {
-                  // not a leaf node
-                  traverse_fun(root.querySelector('ul'));
-                }
-              });
-            }
-            traverse_fun(sidebar.querySelector('div[id="tree-container"]').querySelector('ul'));
-            sidebar.style.display = "block";
-          }
-        );
+        updateHeaderNav(lang);
+        updateSidebarTree(lang);
       }
-
-      // Ειδική περίπτωση για το κουτί αναζήτησης
-      const searchInput = document.getElementById('search-input');
-      if (searchInput) {
-        searchInput.placeholder = globalDict[lang]['search-placeholder'];
-      }
-
-      // Υποσέλιδο     
-      const footer_elements = ["footer-name", "footer-source"];
-      waitForCondition(
-        () => document.getElementById(footer_elements[0]),
-        () => {
-          for(const elem_id of footer_elements) {
-            if (elem_id in globalDict[lang]) {
-              const footerElement = document.getElementById(elem_id);  
-              footerElement.innerText = globalDict[lang][elem_id];
-            } else {
-              console.error(`Missing translation for ${elem_id} in language '${lang}'.`);
-            }
-          }
-        }
-      );
-
-      // Τυχαίο δείγμα
-      const randomSampleTitleElement = document.getElementById('τυχαίο-δείγμα-τίτλος');
-      if (randomSampleTitleElement && randomSampleTitleElement.dataset.unprocessedTitle) {
-        const randomTitle = randomSampleTitleElement.dataset.unprocessedTitle;
-        console.assert(randomTitle in globalDict[lang], `Missing translation for ${randomTitle} in ${lang}`);
-        randomSampleTitleElement.textContent = "";
-        if(randomSampleTitleElement.dataset.extinct === '1') {
-          randomSampleTitleElement.textContent = "†";
-        }
-        randomSampleTitleElement.textContent += globalDict[lang][randomTitle];
-      }
-
-      // Τοποθεσίες δειγμάτων
-      doc.querySelectorAll('[id^="locality-"]').forEach((locality) => {
-        const localityId = locality.id.replace('locality-', '');
-        constructLocalityStr(localityId, lang).then((locality_str) => {
-          locality.innerText = locality_str;
-        });
-      });
-
-      // Cookie banner
-      const cookieBanner = doc.getElementById('cookie-banner');
-      if (cookieBanner) {
-        const subelements = ["cookie-banner-text", "cookie-banner-accept", "cookie-banner-decline"];
-        subelements.forEach((subelem) => {
-          const elem = doc.getElementById(subelem);
-          if (elem) {
-            console.assert(subelem in globalDict[lang], `Missing translation for ${subelem} in language '${lang}'.`);
-            elem.textContent = globalDict[lang][subelem];
-          } else {
-            console.error(`Missing element with id ${subelem}`);
-          }
-        });
-      }
-  });
+      updateSearchPlaceholder(lang);
+      updateFooter(lang);
+      updateRandomSampleTitle(lang);
+      updateLocalityStrings(lang);
+      updateCookieBanner(lang);
+    });
 }
 
 // On page load, apply the selected language


### PR DESCRIPTION
## Summary

`applyLanguage()` previously held a 170-line block covering dropdown rendering, page-key translation, gallery captions, header navigation, breadcrumbs, sidebar tree, search placeholder, footer, random sample title, locality strings, and the cookie banner.

It is now organised into ten focused helpers:

- `updateLanguageDropdown(lang)`
- `updatePageKeys(lang, translations, keys)`
- `updateGalleryCaptions(lang, translations, galleryLength)`
- `updateHeaderNav(lang)`
- `updateSidebarTree(lang)`
- `updateSearchPlaceholder(lang)`
- `updateFooter(lang)`
- `updateRandomSampleTitle(lang)`
- `updateLocalityStrings(lang)`
- `updateCookieBanner(lang)`

`applyLanguage()` reads the script attributes, fetches the page dict, and dispatches to the helpers. The `navPathLoaded && globalDictLoaded` gate that guards header + sidebar updates is preserved.

## Test plan

- [x] `.venv/bin/python -m pyscripts.site_generator.generate_site` exits 0
- [x] Homepage in all three languages — random sample title renders with `†`, footer text translated.
- [ ] Any taxon page — breadcrumbs, sidebar tree counts, search placeholder, locality strings update on language change.
- [x] Locality page — gallery captions and lightbox metadata change with language.
- [x] Cookie banner — translates on language switch (clear localStorage to retest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)