### PR TITLE
Mobile header + taxon page mobile fixes, sticky locality header

### DIFF
--- a/style.css
+++ b/style.css
@@ -326,11 +326,6 @@ header div {
 }
 
 @media (max-width: 600px) {
-    header div {
-        flex-direction: column;
-        align-items: center;
-    }
-
     #search-container,
     #navpath-section,
     .container {
@@ -393,24 +388,54 @@ header div {
 
 @media (max-width: 600px) {
     .header-top {
-        flex-direction: column;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: center;
         align-items: center;
+        gap: 0.4rem 0.8rem;
+        padding: 8px 10px;
+    }
+
+    .header-top > div {
+        padding: 0;
+        flex: 0 0 auto;
+    }
+
+    /* Inner wrapper holding sidebar toggle + lang dropdown — keep them side by side */
+    .header-top > div:first-child {
+        flex-direction: row;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0;
+    }
+
+    .sidebar-toggle img {
+        width: 36px !important;
+        height: auto;
+    }
+
+    .site-title a {
+        font-size: 1rem;
     }
 
     #search-container {
-        width: 100%;
-        margin-top: 10px;
+        flex: 1 1 100%;
+        margin-top: 4px;
         text-align: center;
     }
 
-    .lang-dropdown {
-        margin-top: 10px;
+    #search-input {
+        width: 100%;
+        max-width: 320px;
+        box-sizing: border-box;
     }
 
     .breadcrumbs {
-        flex-direction: column;
-        align-items: center;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: center;
         text-align: center;
+        padding: 6px 10px;
     }
 }
 
@@ -1343,7 +1368,7 @@ body:has(.taxon-hero) section {
   border: 1px solid #d9c79e;
   border-left: 6px solid #b8956a;
   border-radius: 14px;
-  overflow: hidden;
+  overflow: clip;
   box-shadow: 0 4px 14px rgba(30, 25, 20, 0.10);
   transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
 }
@@ -1356,6 +1381,32 @@ body:has(.taxon-hero) section {
 .locality-block[open] {
   box-shadow: 0 10px 30px rgba(30, 25, 20, 0.14);
   border-left-color: #8b5a2b;
+}
+
+/* Sticky header while a locality is open — toggle stays visible while
+   the user scrolls through long galleries */
+.locality-block[open] .locality-header {
+  position: sticky;
+  top: 0;
+  z-index: 4;
+  background: linear-gradient(180deg, #fbf3e3 0%, #f5ead2 100%);
+  backdrop-filter: blur(4px);
+  box-shadow: 0 2px 8px rgba(30, 25, 20, 0.08);
+}
+
+@keyframes localityOpen {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.locality-block[open] .gallery {
+  animation: localityOpen 0.28s ease-out;
 }
 
 .locality-header {
@@ -1667,8 +1718,25 @@ body:has(.taxon-hero) section {
 
 /* Mobile: collapse story columns, tighten paddings */
 @media (max-width: 720px) {
+  body:has(.taxon-hero) main {
+    padding: 12px 4px;
+  }
+  body:has(.taxon-hero) section {
+    padding: 0.75rem 0.3rem;
+  }
+  .taxon-hero {
+    padding: 1.2rem 0.5rem 1rem;
+  }
+  .taxon-hero h2 {
+    font-size: 2rem;
+  }
   .story-visuals {
     grid-template-columns: 1fr;
+    gap: 0.8rem;
+  }
+  .story-illustration img.tax-page-image {
+    width: 100%;
+    max-width: 100%;
   }
   .story-text {
     flex-direction: column;
@@ -1681,15 +1749,45 @@ body:has(.taxon-hero) section {
     box-sizing: border-box;
   }
   .story-phylopic {
-    position: static;
-    max-width: 50%;
+    max-width: 60%;
     margin: 0 auto;
   }
   .story-phylopic img {
-    position: static;
-    margin: 0;
-    height: auto;
-    max-height: 14rem;
+    max-height: 12rem;
+  }
+  .taxon-fossils {
+    gap: 1.5rem;
+    padding: 0.5rem 0.25rem 1rem;
+  }
+  .locality-header {
+    padding: 0.85rem 0.9rem;
+    gap: 0.4rem;
+  }
+  .locality-header-row {
+    gap: 0.65rem;
+  }
+  .locality-preview {
+    height: 64px;
+    width: 64px;
+  }
+  .locality-name {
+    font-size: 1.35rem;
+  }
+  .locality-meta {
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+  }
+  .locality-count {
+    font-size: 0.78rem;
+    padding: 0.18rem 0.55rem;
+  }
+  .locality-toggle {
+    width: 34px;
+    height: 34px;
+    font-size: 1.55rem;
+  }
+  .locality-block .gallery {
+    padding: 0 0.7rem 0.9rem;
   }
   .taxon-fossils .sample-box {
     max-height: 200px;


### PR DESCRIPTION
## Summary
- Site header on mobile no longer cascades `flex-direction: column` to every inner `<div>`, so the sidebar toggle and language dropdown stop stacking vertically. `.header-top` now stays as a wrapping row with smaller padding, smaller sidebar icon, and a search bar that fills the width on wrap.
- Taxon page below 720px: tighter paddings, locality preview 96→64px, name 2→1.35rem, meta letter-spacing eased, toggle 40→34px, AI illustration fills its row, hero h2 from 2.8→2rem.
- Locality `<summary>` becomes `position: sticky` when the section is open, so the close (×) toggle stays visible while scrolling through long galleries. Changed `.locality-block` overflow from `hidden` to `clip` so the block doesn't trap sticky positioning.
- Fade-in animation on the gallery when a section opens.

## Test plan
- [x] Mobile width (< 600px) — site header is compact, no vertical stack of the toggle + lang dropdown, Home/Map/Journal fit on one wrapping row
- [x] Mobile taxon page — locality blocks fit screen, names/meta readable, AI fills width
- [x] Open a locality with many samples, scroll — the summary header stays stuck to the viewport top and the × stays clickable
- [x] Desktop — sticky behaviour also works, no visual regression elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)