### PR TITLE
Add GA4 custom events for interaction tracking

### DIFF
--- a/pyscripts/site_generator/templates/random-sample.js.template
+++ b/pyscripts/site_generator/templates/random-sample.js.template
@@ -52,4 +52,5 @@ if (taxon_extinct(species)) title.dataset.extinct = '1';
 // Set the image link
 var link = doc.getElementById('τυχαίο-δείγμα-σύνδεσμος');
 link.href = getBaseURL() + taxon_to_link(species);
+link.addEventListener('click', () => trackEvent('random_sample', { taxon_id: species }));
 

--- a/scripts/analytics.js
+++ b/scripts/analytics.js
@@ -7,6 +7,14 @@ function setConsent(consent) {
   }
 }
 
+// Fire a GA4 custom event. No-op unless analytics has loaded (i.e. the visitor
+// consented) — we never track non-consenting visitors. Events fired right after
+// consent are safe: the gtag stub queues them in dataLayer until gtag.js loads.
+function trackEvent(name, params) {
+  if (typeof window.gtag !== 'function') return;
+  window.gtag('event', name, params || {});
+}
+
 function loadAnalytics() {
   // Google Analytics script injection
   const script1 = document.createElement('script');

--- a/scripts/explore.js
+++ b/scripts/explore.js
@@ -467,6 +467,11 @@
                     window.removeEventListener("mouseup", onUp);
                     window.removeEventListener("touchmove", onMove);
                     window.removeEventListener("touchend", onUp);
+                    // Fire on drag end, not per move, to avoid flooding events.
+                    trackEvent("timeline_adjusted", {
+                        from_ma: Math.round(filterState.ageFrom),
+                        to_ma: Math.round(filterState.ageTo),
+                    });
                 };
                 window.addEventListener("mousemove", onMove);
                 window.addEventListener("mouseup", onUp);
@@ -499,6 +504,7 @@
                 } else {
                     filterState.countries.add(code);
                     pill.classList.add("active");
+                    trackEvent("explore_filter", { filter_type: "country", filter_value: code });
                 }
                 applyFilters();
             });
@@ -550,6 +556,7 @@
                 } else {
                     filterState.taxa.add(key);
                     pill.classList.add("active");
+                    trackEvent("explore_filter", { filter_type: "taxon", filter_value: key });
                 }
                 renderTaxonChips();
                 applyFilters();
@@ -599,6 +606,7 @@
 
         function selectMatch(taxon) {
             filterState.taxa.add(taxon.key);
+            trackEvent("explore_filter", { filter_type: "taxon", filter_value: taxon.key });
             input.value = "";
             closeDropdown();
             renderTaxonChips();

--- a/scripts/gallery.js
+++ b/scripts/gallery.js
@@ -6,6 +6,8 @@ function init_gallery() {
         speed: 500,
         selector: 'a.gallery-item'
     });
+    // lightGallery fires lgAfterOpen once each time the lightbox opens.
+    gallery.addEventListener('lgAfterOpen', () => trackEvent('gallery_image_open'));
     // fire an event to indicate gallery has been initialized
     const event = new CustomEvent("galleryInitialized");
     document.dispatchEvent(event);

--- a/scripts/language.js
+++ b/scripts/language.js
@@ -70,6 +70,9 @@ function capitalize(s) {
 function setLanguage(lang) {
   localStorage.setItem('language', lang);
   applyLanguage(lang);
+  // Only the explicit-switch path goes through here; applyLanguage on page load
+  // does not, so this measures deliberate switches, not the default language.
+  trackEvent('language_changed', { language: lang });
 }
   
 function getLanguage() {

--- a/scripts/quiz.js
+++ b/scripts/quiz.js
@@ -1233,6 +1233,27 @@ function pointsForQuestion(q) {
   return Math.max(1, QUIZ_MAX_POINTS_PER_Q - q.hintsUsed);
 }
 
+// `type:target` is stable per question, so GA4 can rank questions by % correct
+// and by median answer time.
+function quizQuestionId(q) {
+  return `${q.type}:${q.target}`;
+}
+
+function emitQuizAnswer(q, isCorrect, extra) {
+  const params = {
+    question_id: quizQuestionId(q),
+    game_type: q.type,
+    target: q.target,
+    correct: isCorrect,
+    answer_time_ms: Math.round(performance.now() - q.shownAt),
+    hints_used: q.hintsUsed,
+    question_index: QuizState.round.index,
+    points_earned: q.pointsEarned,
+  };
+  if (q.sampleId) params.sample_id = q.sampleId;
+  trackEvent("quiz_answer", Object.assign(params, extra || {}));
+}
+
 function handleAnswer(idx) {
   const q = QuizState.current;
   if (q.answered) return;
@@ -1247,6 +1268,7 @@ function handleAnswer(idx) {
   const pointsEarned = isCorrect ? pointsForQuestion(q) : 0;
   q.pointsEarned = pointsEarned;
   QuizState.round.score += pointsEarned;
+  emitQuizAnswer(q, isCorrect);
   // Visual feedback on choices.
   document.querySelectorAll(".choice-button").forEach((btn, i) => {
     btn.disabled = true;
@@ -1291,6 +1313,7 @@ function finalizeSortAnswer() {
   }
   q.pointsEarned = correctPositions;
   QuizState.round.score += correctPositions;
+  emitQuizAnswer(q, correctPositions === q.choices.length, { correct_positions: correctPositions });
   const lang = getLang();
   renderSortChoices(q); // re-render in locked state with correctness markers
   // Append correct-position badges as a separate decoration on each card.
@@ -1318,6 +1341,7 @@ function handleHint() {
   const q = QuizState.current;
   if (q.hintsUsed < q.hintMax) {
     q.hintsUsed += 1;
+    trackEvent("quiz_hint_used", { question_id: quizQuestionId(q), game_type: q.type });
     renderMedia(q);
     if (q.hintsUsed >= q.hintMax) {
       document.getElementById("quiz-hint").style.display = "none";
@@ -1341,6 +1365,7 @@ function buildAndShowQuestion() {
     return;
   }
   q.answered = false;
+  q.shownAt = performance.now();
   QuizState.current = q;
   QuizState.round.typeHistory.push(q.type);
   if (q.target) {
@@ -1385,7 +1410,9 @@ function startRound() {
     usedTaxa: recentAcrossSessions,
     typeHistory: [],
     targetsThisRound: [],
+    startedAt: performance.now(),
   };
+  trackEvent("quiz_started");
   document.getElementById("quiz-intro-screen").style.display = "none";
   document.getElementById("quiz-end-screen").style.display = "none";
   document.getElementById("quiz-game-screen").style.display = "";
@@ -1398,6 +1425,11 @@ function endRound() {
   const maxScore = QUIZ_ROUND_SIZE * QUIZ_MAX_POINTS_PER_Q;
   document.getElementById("quiz-final-score-value").textContent =
     `${QuizState.round.score}/${maxScore}`;
+  trackEvent("quiz_completed", {
+    score: QuizState.round.score,
+    max_score: maxScore,
+    total_time_ms: Math.round(performance.now() - QuizState.round.startedAt),
+  });
   persistRecentTargets(QuizState.round.targetsThisRound);
 }
 

--- a/scripts/random-sample.js
+++ b/scripts/random-sample.js
@@ -3423,4 +3423,5 @@ if (taxon_extinct(species)) title.dataset.extinct = '1';
 // Set the image link
 var link = doc.getElementById('τυχαίο-δείγμα-σύνδεσμος');
 link.href = getBaseURL() + taxon_to_link(species);
+link.addEventListener('click', () => trackEvent('random_sample', { taxon_id: species }));
 

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -21,6 +21,7 @@ waitForCondition(
 
       let currentResults = [];
       let highlightedIndex = -1;
+      let searchDebounce;
 
       function setHighlight(idx) {
         const items = searchResults.querySelectorAll('li');
@@ -39,6 +40,9 @@ waitForCondition(
       }
 
       function selectResult(result) {
+        const resultType = result.path.startsWith('/tree/') ? 'taxon'
+          : result.path.startsWith('/localities/') ? 'locality' : 'page';
+        trackEvent('search_select', { result_type: resultType, path: result.path });
         window.location.href = getBaseURL() + result.path;
       }
 
@@ -57,6 +61,13 @@ waitForCondition(
               return translation.toLowerCase();
             }).some((s) => s.includes(searchTerm));
           });
+
+          // Debounced so we log committed searches, not every keystroke.
+          // results_count === 0 surfaces searches that find nothing (collection gaps).
+          clearTimeout(searchDebounce);
+          searchDebounce = setTimeout(() => {
+            trackEvent('search', { search_term: searchTerm, results_count: results.length });
+          }, 800);
 
           if (results.length > 0) {
             currentResults = results;

--- a/scripts/slideshow.js
+++ b/scripts/slideshow.js
@@ -46,6 +46,7 @@ function initialize_slideshow() {
         slideshowImages = shuffleArray(collectAllImages());
         if (slideshowImages.length === 0) return;
 
+        trackEvent('slideshow_started', { count: slideshowImages.length });
         currentSlide = 0;
         slideshowTotal.textContent = slideshowImages.length;
         slideshowModal.classList.add('active');


### PR DESCRIPTION
## Summary

Adds custom GA4 events so we can see *how* the site's interactive features are used, not just which pages are visited. Previously GA4 sent nothing beyond automatic page views.

A single consent-gated helper `trackEvent()` (in `analytics.js`) routes every event; it no-ops unless `gtag` is present, so **non-consenting visitors are never tracked** — no extra consent plumbing. Continuously-firing handlers (search input, timeline drag) are debounced / fired on commit to avoid event spam. Per-page taxon/locality views are left to GA4's automatic page-view tracking (URL-based) rather than duplicated.

## Events

- **Quiz** (`quiz.js`): `quiz_started`; per-question `quiz_answer` with `question_id` (`type:target`), `correct`, `answer_time_ms`, `hints_used`, `points_earned`; `quiz_completed` (`score`, `total_time_ms`); `quiz_hint_used`. Lets us rank questions by difficulty (% correct) and median answer time.
- **Search** (`search.js`): debounced `search` with `search_term` + `results_count` (surfaces zero-result searches = collection gaps); `search_select` with `result_type`.
- **Language** (`language.js`): `language_changed` on explicit switches only.
- **Gallery/slideshow** (`gallery.js`, `slideshow.js`): `gallery_image_open`, `slideshow_started`.
- **Explore** (`explore.js`): `explore_filter` (country/taxon), `timeline_adjusted` (on drag end).
- **Random sample** (`random-sample.js.template` → regenerated): `random_sample`.

> Note: every question builder currently sets `hintMax: 0`, so `quiz_hint_used` is wired but will not fire until hints are enabled.

## Notes
- Verified that every page loading an instrumented script also loads `analytics.js`, so `trackEvent` is always defined.
- Custom event *parameters* have been registered in GA4 Admin → Custom definitions (required for them to appear in reports).
- Events verified live via `dataLayer` / DebugView.

🤖 Generated with [Claude Code](https://claude.com/claude-code)